### PR TITLE
fix(Project): Remove Travis steps for pre-commit hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
   - sudo apt-get update
   - pyenv versions
   - pyenv global 3.7.1
-  - pip3 install pre-commit
   - nvm install 12
   - npm install -g npm@6.x
   #- '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $my_key -iv $my_iv -in myservice.env.enc -out myservice.env -d || true'
@@ -27,8 +26,6 @@ install:
 
 script:
   - make travis-ci
-  - pre-commit install
-  - pre-commit run detect-secrets
 
 # To enable semantic-release, uncomment these sections.
 before_deploy:


### PR DESCRIPTION
Signed-off-by: James Hart <jhart@uk.ibm.com>

## PR summary
The addition of detect-secrets pre-commit hooks into Travis was erroneous and needs to be removed.
I'm leaving the .pre-commit-config.yaml in place so that developers can use the pre-commit hook themselves if desired.

**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->