### PR TITLE
fix(Registry): Ensure region aliases work

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-02-22T10:25:22Z",
+  "generated_at": "2021-03-11T14:09:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -89,7 +89,7 @@
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5672,
+        "line_number": 5816,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/containerregistryv1/container_registry_v1.go
+++ b/containerregistryv1/container_registry_v1.go
@@ -125,9 +125,13 @@ func GetServiceURLForRegion(region string) (string, error) {
 	var endpoints = map[string]string{
 		"us-south":   "https://us.icr.io",  // us-south
 		"uk-south":   "https://uk.icr.io",  // uk-south
+		"eu-gb":      "https://uk.icr.io",  // eu-gb
 		"eu-central": "https://de.icr.io",  // eu-central
+		"eu-de":      "https://de.icr.io",  // eu-de
 		"ap-north":   "https://jp.icr.io",  // ap-north
+		"jp-tok":     "https://jp.icr.io",  // jp-tok
 		"ap-south":   "https://au.icr.io",  // ap-south
+		"au-syd":     "https://au.icr.io",  // au-syd
 		"global":     "https://icr.io",     // global
 		"jp-osa":     "https://jp2.icr.io", // jp-osa
 	}

--- a/containerregistryv1/container_registry_v1_test.go
+++ b/containerregistryv1/container_registry_v1_test.go
@@ -181,7 +181,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://uk.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://de.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -189,7 +197,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -618,7 +634,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://uk.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://de.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -626,7 +650,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -1996,7 +2028,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://uk.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://de.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -2004,7 +2044,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -2295,7 +2343,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://uk.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://de.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -2303,7 +2359,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -3254,7 +3318,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://uk.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://de.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -3262,7 +3334,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -3689,7 +3769,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://uk.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://de.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -3697,7 +3785,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -4126,7 +4222,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://uk.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://de.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -4134,7 +4238,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -4993,7 +5105,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://uk.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://de.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -5001,7 +5121,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -5428,7 +5556,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://uk.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://de.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -5436,7 +5572,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -5790,7 +5934,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://uk.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://de.icr.io"))
 			Expect(err).To(BeNil())
 
@@ -5798,7 +5950,15 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 


### PR DESCRIPTION
Signed-off-by: James Hart <jhart@uk.ibm.com>

## PR summary
Regenerated SDK having added region aliases into the api-doc.
This ensures that users can get the right registry endpoint regardless of whether they use `eu-gb` or `uk-south` (for example).

**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe) Backwards compatibility (with existing Terraform provider)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->