### PR TITLE
fix(Registry): Correct getImageManifest definition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,13 @@
 #
 # This line indicates we will use the hook from ibm/detect-secrets to run scan during committing phase.
 # Whitewater/whitewater-detect-secrets would sync code to ibm/detect-secrets upon merge.
+repos:
 - repo: https://github.com/ibm/detect-secrets
   # If you desire to use a specific version of detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
   # You are encouraged to use static refs such as tags, instead of branch name
   #
   # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-  rev: master
+  rev: 0.13.1+ibm.32.dss
   hooks:
     - id: detect-secrets # pragma: whitelist secret
       # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-03-30T14:45:36Z",
+  "generated_at": "2021-03-30T16:05:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -64,6 +64,24 @@
     }
   ],
   "results": {
+    "containerregistryv1/container_registry_v1.go": [
+      {
+        "hashed_secret": "783923e57ba5e8f1044632c31fd806ee24814bb5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 191,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0a25ba5991316bdda4a9b3abcee2106016df28a0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 244,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "containerregistryv1/container_registry_v1_examples_test.go": [
       {
         "hashed_secret": "c4a53180c86d1fdbf0d0421913e1dfc45d66e42a",
@@ -125,7 +143,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.29.dss",
+  "version": "0.13.1+ibm.32.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-03-24T13:18:53Z",
+  "generated_at": "2021-03-30T14:45:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -64,24 +64,6 @@
     }
   ],
   "results": {
-    "containerregistryv1/container_registry_v1.go": [
-      {
-        "hashed_secret": "783923e57ba5e8f1044632c31fd806ee24814bb5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 191,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0a25ba5991316bdda4a9b3abcee2106016df28a0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 244,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "containerregistryv1/container_registry_v1_examples_test.go": [
       {
         "hashed_secret": "c4a53180c86d1fdbf0d0421913e1dfc45d66e42a",
@@ -107,7 +89,7 @@
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5816,
+        "line_number": 5884,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/containerregistryv1/container_registry_v1.go
+++ b/containerregistryv1/container_registry_v1.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.28.0-55613c9e-20210220-164656
+ * IBM OpenAPI SDK Code Generator Version: 3.29.1-b338fb38-20210313-010605
  */
 
 // Package containerregistryv1 : Operations and models for the ContainerRegistryV1 service
@@ -686,12 +686,12 @@ func (containerRegistry *ContainerRegistryV1) InspectImageWithContext(ctx contex
 
 // GetImageManifest : Get image manifest
 // Get the manifest for a container image in the private registry.
-func (containerRegistry *ContainerRegistryV1) GetImageManifest(getImageManifestOptions *GetImageManifestOptions) (response *core.DetailedResponse, err error) {
+func (containerRegistry *ContainerRegistryV1) GetImageManifest(getImageManifestOptions *GetImageManifestOptions) (result map[string]interface{}, response *core.DetailedResponse, err error) {
 	return containerRegistry.GetImageManifestWithContext(context.Background(), getImageManifestOptions)
 }
 
 // GetImageManifestWithContext is an alternate form of the GetImageManifest method which supports a Context parameter
-func (containerRegistry *ContainerRegistryV1) GetImageManifestWithContext(ctx context.Context, getImageManifestOptions *GetImageManifestOptions) (response *core.DetailedResponse, err error) {
+func (containerRegistry *ContainerRegistryV1) GetImageManifestWithContext(ctx context.Context, getImageManifestOptions *GetImageManifestOptions) (result map[string]interface{}, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(getImageManifestOptions, "getImageManifestOptions cannot be nil")
 	if err != nil {
 		return
@@ -731,8 +731,6 @@ func (containerRegistry *ContainerRegistryV1) GetImageManifestWithContext(ctx co
 		return
 	}
 
-	// MANUALLY MODIFIED GENERATED CODE. To pass in a result object
-	var result []byte
 	response, err = containerRegistry.Service.Request(request, &result)
 
 	return

--- a/containerregistryv1/container_registry_v1_examples_test.go
+++ b/containerregistryv1/container_registry_v1_examples_test.go
@@ -308,8 +308,9 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			)
 
 			// Because the content-type is not application/json, the map[string]interface{} response
-			// will not be populated by the core SDK libraries.
-			// You must use response.GetResult() and handle the bytes as youc choose.
+			//  will not be populated by the core SDK libraries.
+			// Use response.GetResult() and handle the bytes as you choose.
+			// The Content-Type header will tell you which type of Manifest is in the payload.
 			_, response, err := containerRegistryService.GetImageManifest(getImageManifestOptions)
 			if err != nil {
 				panic(err)

--- a/containerregistryv1/container_registry_v1_examples_test.go
+++ b/containerregistryv1/container_registry_v1_examples_test.go
@@ -221,7 +221,7 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			// begin-bulk_delete_images
 
 			bulkDeleteImagesOptions := containerRegistryService.NewBulkDeleteImagesOptions(
-				[]string{"testString"},
+				[]string{"image name"},
 			)
 
 			imageBulkDeleteResult, response, err := containerRegistryService.BulkDeleteImages(bulkDeleteImagesOptions)
@@ -264,8 +264,8 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			// begin-tag_image
 
 			tagImageOptions := containerRegistryService.NewTagImageOptions(
-				"testString",
-				"testString",
+				"from image name",
+				"to image name",
 			)
 
 			response, err := containerRegistryService.TagImage(tagImageOptions)
@@ -283,7 +283,7 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			// begin-inspect_image
 
 			inspectImageOptions := containerRegistryService.NewInspectImageOptions(
-				"testString",
+				"image name",
 			)
 
 			imageInspection, response, err := containerRegistryService.InspectImage(inspectImageOptions)
@@ -304,13 +304,24 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			// begin-get_image_manifest
 
 			getImageManifestOptions := containerRegistryService.NewGetImageManifestOptions(
-				"testString",
+				"image name",
 			)
 
-			response, err := containerRegistryService.GetImageManifest(getImageManifestOptions)
+			// Because the content-type is not application/json, the map[string]interface{} response
+			// will not be populated by the core SDK libraries.
+			// You must use response.GetResult() and handle the bytes as youc choose.
+			_, response, err := containerRegistryService.GetImageManifest(getImageManifestOptions)
 			if err != nil {
 				panic(err)
 			}
+
+			// contentType might be, for example, "application/vnd.docker.distribution.manifest.v2+json"
+			contentType := response.Headers.Get("Content-Type")
+			rawOutput := response.GetResult().([]byte)
+
+			// You could use "github.com/docker/distribution/manifest/schema2"
+			//  tempManifest := &schema2.DeserializedManifest{}
+			//  err := tempManifest.UnmarshalJSON(rawOutput)
 
 			// end-get_image_manifest
 
@@ -379,8 +390,8 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			// begin-assign_namespace
 
 			assignNamespaceOptions := containerRegistryService.NewAssignNamespaceOptions(
-				"testString",
-				"testString",
+				"Resource Group ID",
+				namespaceLink,
 			)
 
 			namespace, response, err := containerRegistryService.AssignNamespace(assignNamespaceOptions)
@@ -509,7 +520,7 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 		It(`AnalyzeRetentionPolicy request example`, func() {
 			// begin-analyze_retention_policy
 
-			analyzeRetentionPolicyOptions := containerRegistryService.NewAnalyzeRetentionPolicyOptions("birds")
+			analyzeRetentionPolicyOptions := containerRegistryService.NewAnalyzeRetentionPolicyOptions(namespaceLink)
 			analyzeRetentionPolicyOptions.SetImagesPerRepo(int64(10))
 			analyzeRetentionPolicyOptions.SetRetainUntagged(false)
 
@@ -531,7 +542,7 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			// begin-get_retention_policy
 
 			getRetentionPolicyOptions := containerRegistryService.NewGetRetentionPolicyOptions(
-				"testString",
+				namespaceLink,
 			)
 
 			retentionPolicy, response, err := containerRegistryService.GetRetentionPolicy(getRetentionPolicyOptions)
@@ -571,7 +582,7 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			// begin-restore_tags
 
 			restoreTagsOptions := containerRegistryService.NewRestoreTagsOptions(
-				"testString",
+				"image name", // Fully qualified including digest
 			)
 
 			restoreResult, response, err := containerRegistryService.RestoreTags(restoreTagsOptions)
@@ -592,7 +603,7 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			// begin-restore_image
 
 			restoreImageOptions := containerRegistryService.NewRestoreImageOptions(
-				"testString",
+				"image name",
 			)
 
 			response, err := containerRegistryService.RestoreImage(restoreImageOptions)
@@ -628,7 +639,7 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			// begin-delete_image_tag
 
 			deleteImageTagOptions := containerRegistryService.NewDeleteImageTagOptions(
-				"testString",
+				"image name",
 			)
 
 			imageDeleteResult, response, err := containerRegistryService.DeleteImageTag(deleteImageTagOptions)
@@ -649,7 +660,7 @@ var _ = Describe(`ContainerRegistryV1 Examples Tests`, func() {
 			// begin-delete_image
 
 			deleteImageOptions := containerRegistryService.NewDeleteImageOptions(
-				"testString",
+				"image name",
 			)
 
 			imageDeleteResult, response, err := containerRegistryService.DeleteImage(deleteImageOptions)

--- a/containerregistryv1/container_registry_v1_integration_test.go
+++ b/containerregistryv1/container_registry_v1_integration_test.go
@@ -346,7 +346,10 @@ var _ = Describe(`ContainerRegistryV1 Integration Tests`, func() {
 				Image: core.StringPtr(fmt.Sprintf("%s/%s/sdktest:1", registryDNSName, namespaceLink)),
 			}
 
-			response, err := containerRegistry.GetImageManifest(getImageManifestOptions)
+			// Because the content-type is not application/json, the map[string]interface{} response
+			// will not be populated by the core SDK libraries.
+			// We must use response.GetResult() and handle the bytes as we choose.
+			_, response, err := containerRegistry.GetImageManifest(getImageManifestOptions)
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
@@ -358,7 +361,6 @@ var _ = Describe(`ContainerRegistryV1 Integration Tests`, func() {
 			jsErr := json.Unmarshal(response.GetResult().([]byte), &outputMap)
 			Expect(jsErr).To(BeNil())
 			Expect(outputMap["schemaVersion"]).To(Equal(float64(2)))
-
 		})
 	})
 

--- a/containerregistryv1/container_registry_v1_test.go
+++ b/containerregistryv1/container_registry_v1_test.go
@@ -1813,6 +1813,66 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 	Describe(`GetImageManifest(getImageManifestOptions *GetImageManifestOptions)`, func() {
 		account := "testString"
 		getImageManifestPath := "/api/v1/images/testString/manifest"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getImageManifestPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.Header["Account"]).ToNot(BeNil())
+					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"mapKey": "anyValue"}`)
+				}))
+			})
+			It(`Invoke GetImageManifest successfully with retries`, func() {
+				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+					Account:       core.StringPtr(account),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(containerRegistryService).ToNot(BeNil())
+				containerRegistryService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetImageManifestOptions model
+				getImageManifestOptionsModel := new(containerregistryv1.GetImageManifestOptions)
+				getImageManifestOptionsModel.Image = core.StringPtr("testString")
+				getImageManifestOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := containerRegistryService.GetImageManifestWithContext(ctx, getImageManifestOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				containerRegistryService.DisableRetries()
+				result, response, operationErr := containerRegistryService.GetImageManifest(getImageManifestOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = containerRegistryService.GetImageManifestWithContext(ctx, getImageManifestOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1824,7 +1884,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 
 					Expect(req.Header["Account"]).ToNot(BeNil())
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"mapKey": "anyValue"}`)
 				}))
 			})
 			It(`Invoke GetImageManifest successfully`, func() {
@@ -1837,9 +1900,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				Expect(containerRegistryService).ToNot(BeNil())
 
 				// Invoke operation with nil options model (negative test)
-				response, operationErr := containerRegistryService.GetImageManifest(nil)
+				result, response, operationErr := containerRegistryService.GetImageManifest(nil)
 				Expect(operationErr).NotTo(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 
 				// Construct an instance of the GetImageManifestOptions model
 				getImageManifestOptionsModel := new(containerregistryv1.GetImageManifestOptions)
@@ -1847,9 +1911,11 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				getImageManifestOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
-				response, operationErr = containerRegistryService.GetImageManifest(getImageManifestOptionsModel)
+				result, response, operationErr = containerRegistryService.GetImageManifest(getImageManifestOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
 			})
 			It(`Invoke GetImageManifest with error: Operation validation and request error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
@@ -1867,16 +1933,18 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				// Invoke operation with empty URL (negative test)
 				err := containerRegistryService.SetServiceURL("")
 				Expect(err).To(BeNil())
-				response, operationErr := containerRegistryService.GetImageManifest(getImageManifestOptionsModel)
+				result, response, operationErr := containerRegistryService.GetImageManifest(getImageManifestOptionsModel)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 				// Construct a second instance of the GetImageManifestOptions model with no property values
 				getImageManifestOptionsModelNew := new(containerregistryv1.GetImageManifestOptions)
 				// Invoke operation with invalid model (negative test)
-				response, operationErr = containerRegistryService.GetImageManifest(getImageManifestOptionsModelNew)
+				result, response, operationErr = containerRegistryService.GetImageManifest(getImageManifestOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 			})
 			AfterEach(func() {
 				testServer.Close()


### PR DESCRIPTION
## PR summary
SDK regenerated from latest apidoc, with the ImageManifest schema now defined to contain properties.
This has changed the signature of the function, but has removed the need for hand-edited code.
Example and integration tests updated accordingly.
Also modified naming in the examples, to match other SDKs.

**Fixes:** https://github.com/IBM/container-registry-go-sdk/issues/14

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
`GetImageManifest` returns a core response and and error. You use the bytes from the result in the response to access the payload.

## What is the new behavior?  
There's a new (first) returned value from the function, `result`. This is only populated if the content-type is application/json (which it will not be). So the code to handle the payload can largely remain unchanged, but you need to ignore the new `result` object.

## Does this PR introduce a breaking change?    
- [x] Yes
- [ ] No

Before:

```Go
response, err := containerRegistryService.GetImageManifest(getImageManifestOptions)
```

After:

```Go
_, response, err := containerRegistryService.GetImageManifest(getImageManifestOptions)
```

## Other information
This is still just a bump in minor version, as the SDK is pre-release. So this kind of breaking change is acceptable