### PR TITLE
fix(Registry): Regenerate to include ca-tor to ca.icr.io mapping

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-03-30T16:05:31Z",
+  "generated_at": "2021-06-02T13:07:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -69,7 +69,7 @@
         "hashed_secret": "783923e57ba5e8f1044632c31fd806ee24814bb5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 191,
+        "line_number": 192,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -77,7 +77,7 @@
         "hashed_secret": "0a25ba5991316bdda4a9b3abcee2106016df28a0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 244,
+        "line_number": 245,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -107,7 +107,7 @@
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5884,
+        "line_number": 5920,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/containerregistryv1/container_registry_v1.go
+++ b/containerregistryv1/container_registry_v1.go
@@ -134,6 +134,7 @@ func GetServiceURLForRegion(region string) (string, error) {
 		"au-syd":     "https://au.icr.io",  // au-syd
 		"global":     "https://icr.io",     // global
 		"jp-osa":     "https://jp2.icr.io", // jp-osa
+		"ca-tor":     "https://ca.icr.io",  // ca-tor
 	}
 
 	if url, ok := endpoints[region]; ok {
@@ -513,7 +514,8 @@ func (containerRegistry *ContainerRegistryV1) ListImageDigestsWithContext(ctx co
 }
 
 // TagImage : Create tag
-// Create a new tag in a private registry that refers to an existing image in the same region.
+// Create a new tag in a private registry that refers to an existing image in the same region. If the fromimage has Red
+// Hat® signatures and the toimage is in a different repository, those signatures are copied to that repository.
 func (containerRegistry *ContainerRegistryV1) TagImage(tagImageOptions *TagImageOptions) (response *core.DetailedResponse, err error) {
 	return containerRegistry.TagImageWithContext(context.Background(), tagImageOptions)
 }

--- a/containerregistryv1/container_registry_v1_test.go
+++ b/containerregistryv1/container_registry_v1_test.go
@@ -217,6 +217,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp2.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("INVALID_REGION")
 			Expect(url).To(BeEmpty())
 			Expect(err).ToNot(BeNil())
@@ -668,6 +672,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 
 			url, err = containerregistryv1.GetServiceURLForRegion("jp-osa")
 			Expect(url).To(Equal("https://jp2.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
 			Expect(err).To(BeNil())
 
 			url, err = containerregistryv1.GetServiceURLForRegion("INVALID_REGION")
@@ -2132,6 +2140,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp2.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("INVALID_REGION")
 			Expect(url).To(BeEmpty())
 			Expect(err).ToNot(BeNil())
@@ -2445,6 +2457,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 
 			url, err = containerregistryv1.GetServiceURLForRegion("jp-osa")
 			Expect(url).To(Equal("https://jp2.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
 			Expect(err).To(BeNil())
 
 			url, err = containerregistryv1.GetServiceURLForRegion("INVALID_REGION")
@@ -3422,6 +3438,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp2.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("INVALID_REGION")
 			Expect(url).To(BeEmpty())
 			Expect(err).ToNot(BeNil())
@@ -3871,6 +3891,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 
 			url, err = containerregistryv1.GetServiceURLForRegion("jp-osa")
 			Expect(url).To(Equal("https://jp2.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
 			Expect(err).To(BeNil())
 
 			url, err = containerregistryv1.GetServiceURLForRegion("INVALID_REGION")
@@ -4324,6 +4348,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 
 			url, err = containerregistryv1.GetServiceURLForRegion("jp-osa")
 			Expect(url).To(Equal("https://jp2.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
 			Expect(err).To(BeNil())
 
 			url, err = containerregistryv1.GetServiceURLForRegion("INVALID_REGION")
@@ -5209,6 +5237,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp2.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("INVALID_REGION")
 			Expect(url).To(BeEmpty())
 			Expect(err).ToNot(BeNil())
@@ -5660,6 +5692,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://jp2.icr.io"))
 			Expect(err).To(BeNil())
 
+			url, err = containerregistryv1.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("INVALID_REGION")
 			Expect(url).To(BeEmpty())
 			Expect(err).ToNot(BeNil())
@@ -6036,6 +6072,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 
 			url, err = containerregistryv1.GetServiceURLForRegion("jp-osa")
 			Expect(url).To(Equal("https://jp2.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = containerregistryv1.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
 			Expect(err).To(BeNil())
 
 			url, err = containerregistryv1.GetServiceURLForRegion("INVALID_REGION")


### PR DESCRIPTION
Signed-off-by: James Hart <jhart@uk.ibm.com>

## PR summary
sdk regenerated to pull in new ca.icr.io instance from the apidocs

**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
Users would need to set the endpoint explicitly if using ca-tor

## What is the new behavior?  
Users can get the registry endpoint by passing in `ca-tor` to the `GetServiceURLForRegion` function.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->