### PR TITLE
fix(registry): Update default service URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,4 +11,3 @@ Before that, please search for similar issues. It's possible that someone has al
 # General Information
 For general guidance on contributing to this project, please see
 [this link](https://github.com/IBM/ibm-cloud-sdk-common/blob/master/CONTRIBUTING_go.md)
-

--- a/containerregistryv1/container_registry_v1.go
+++ b/containerregistryv1/container_registry_v1.go
@@ -44,7 +44,7 @@ type ContainerRegistryV1 struct {
 }
 
 // DefaultServiceURL is the default URL to make service requests to.
-const DefaultServiceURL = "https://us.icr.io"
+const DefaultServiceURL = "https://icr.io"
 
 // DefaultServiceName is the default key used to find external configuration information.
 const DefaultServiceName = "container_registry"


### PR DESCRIPTION
Signed-off-by: James Hart <jhart@uk.ibm.com>

## PR summary
Makes the global registry (icr.io) the default fallback , rather than us-south.

**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
The constant `DefaultServiceURL` points to us.icr.io. We are not aware of this being consumed anywhere other than the IBM Terraform provider.

## What is the new behavior?  
The constant `DefaultServiceURL` points to icr.io

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->