### PR TITLE
Vav4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   # You are encouraged to use static refs such as tags, instead of branch name
   #
   # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-  rev: 0.13.1+ibm.37.dss
+  rev: 0.13.1+ibm.60.dss
   hooks:
     - id: detect-secrets # pragma: whitelist secret
       # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,13 +3,16 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-09-16T14:22:18Z",
+  "generated_at": "2023-05-23T11:43:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
     },
     {
       "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
     },
     {
       "base64_limit": 4.5,
@@ -27,6 +30,9 @@
     {
       "ghe_instance": "github.ibm.com",
       "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
     },
     {
       "hex_limit": 3,
@@ -49,6 +55,9 @@
       "name": "MailchimpDetector"
     },
     {
+      "name": "NpmDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
     },
     {
@@ -56,6 +65,9 @@
     },
     {
       "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
     },
     {
       "name": "StripeDetector"
@@ -85,10 +97,18 @@
     ],
     "containerregistryv1/container_registry_v1_examples_test.go": [
       {
+        "hashed_secret": "811424347556b661512671f7a53aafa6aaf03ca2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "c4a53180c86d1fdbf0d0421913e1dfc45d66e42a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 65,
+        "line_number": 72,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -98,7 +118,7 @@
         "hashed_secret": "c4a53180c86d1fdbf0d0421913e1dfc45d66e42a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 44,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -108,43 +128,43 @@
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 62,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
-    "vulnerabilityadvisorv3/vulnerability_advisor_v3_examples_test.go": [
+    "vulnerabilityadvisorv4/vulnerability_advisor_v4_examples_test.go": [
+      {
+        "hashed_secret": "811424347556b661512671f7a53aafa6aaf03ca2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "vulnerabilityadvisorv4/vulnerability_advisor_v4_integration_test.go": [
       {
         "hashed_secret": "c4a53180c86d1fdbf0d0421913e1dfc45d66e42a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 44,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
-    "vulnerabilityadvisorv3/vulnerability_advisor_v3_integration_test.go": [
-      {
-        "hashed_secret": "c4a53180c86d1fdbf0d0421913e1dfc45d66e42a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 41,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "vulnerabilityadvisorv3/vulnerability_advisor_v3_test.go": [
+    "vulnerabilityadvisorv4/vulnerability_advisor_v4_test.go": [
       {
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 62,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ]
   },
-  "version": "0.13.1+ibm.37.dss",
+  "version": "0.13.1+ibm.60.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,13 @@ unittest:
 
 alltest:
 	go test `go list ./... | grep -v samples` -v -tags=integration
+	go test `go list ./... | grep -v samples` -v -tags=examples
 
 registryintegration:
 	go test ./containerregistryv1 -v -tags=integration
 
 vaintegration:
-	go test ./vulnerabilityadvisorv3 -v -tags=integration
+	go test ./vulnerabilityadvisorv4 -v -tags=integration
 
 lint:
 	golangci-lint run

--- a/containerregistryv1/container_registry_v1.go
+++ b/containerregistryv1/container_registry_v1.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.38.1-1037b405-20210908-184149
+ * IBM OpenAPI SDK Code Generator Version: 3.72.0-5d70f2bb-20230511-203609
  */
 
 // Package containerregistryv1 : Operations and models for the ContainerRegistryV1 service
@@ -123,19 +123,19 @@ func NewContainerRegistryV1(options *ContainerRegistryV1Options) (service *Conta
 // GetServiceURLForRegion returns the service URL to be used for the specified region
 func GetServiceURLForRegion(region string) (string, error) {
 	var endpoints = map[string]string{
-		"us-south":   "https://us.icr.io",  // us-south
-		"uk-south":   "https://uk.icr.io",  // uk-south
-		"eu-gb":      "https://uk.icr.io",  // eu-gb
-		"eu-central": "https://de.icr.io",  // eu-central
-		"eu-de":      "https://de.icr.io",  // eu-de
-		"ap-north":   "https://jp.icr.io",  // ap-north
-		"jp-tok":     "https://jp.icr.io",  // jp-tok
-		"ap-south":   "https://au.icr.io",  // ap-south
-		"au-syd":     "https://au.icr.io",  // au-syd
-		"global":     "https://icr.io",     // global
-		"jp-osa":     "https://jp2.icr.io", // jp-osa
-		"ca-tor":     "https://ca.icr.io",  // ca-tor
-		"br-sao":     "https://br.icr.io",  // br-sao
+		"global": "https://icr.io", // global
+		"us-south": "https://us.icr.io", // us-south
+		"uk-south": "https://uk.icr.io", // uk-south
+		"eu-gb": "https://uk.icr.io", // eu-gb
+		"eu-central": "https://de.icr.io", // eu-central
+		"eu-de": "https://de.icr.io", // eu-de
+		"ap-north": "https://jp.icr.io", // ap-north
+		"jp-tok": "https://jp.icr.io", // jp-tok
+		"ap-south": "https://au.icr.io", // ap-south
+		"au-syd": "https://au.icr.io", // au-syd
+		"jp-osa": "https://jp2.icr.io", // jp-osa
+		"ca-tor": "https://ca.icr.io", // ca-tor
+		"br-sao": "https://br.icr.io", // br-sao
 	}
 
 	if url, ok := endpoints[region]; ok {
@@ -1963,10 +1963,10 @@ func (options *AnalyzeRetentionPolicyOptions) SetHeaders(param map[string]string
 // AssignNamespaceOptions : The AssignNamespace options.
 type AssignNamespaceOptions struct {
 	// The ID of the resource group to which you want to add the namespace.
-	XAuthResourceGroup *string `json:"-" validate:"required"`
+	XAuthResourceGroup *string `json:"X-Auth-Resource-Group" validate:"required"`
 
 	// The name of the namespace that you want to udpate.
-	Name *string `json:"-" validate:"required,ne="`
+	Name *string `json:"name" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -1976,7 +1976,7 @@ type AssignNamespaceOptions struct {
 func (*ContainerRegistryV1) NewAssignNamespaceOptions(xAuthResourceGroup string, name string) *AssignNamespaceOptions {
 	return &AssignNamespaceOptions{
 		XAuthResourceGroup: core.StringPtr(xAuthResourceGroup),
-		Name:               core.StringPtr(name),
+		Name: core.StringPtr(name),
 	}
 }
 
@@ -2239,10 +2239,10 @@ func UnmarshalConfig(m map[string]json.RawMessage, result interface{}) (err erro
 // CreateNamespaceOptions : The CreateNamespace options.
 type CreateNamespaceOptions struct {
 	// The name of the namespace that you want to create.
-	Name *string `json:"-" validate:"required,ne="`
+	Name *string `json:"name" validate:"required,ne="`
 
 	// The ID of the resource group to which you want to add the namespace.
-	XAuthResourceGroup *string `json:"-"`
+	XAuthResourceGroup *string `json:"X-Auth-Resource-Group,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -2277,7 +2277,7 @@ func (options *CreateNamespaceOptions) SetHeaders(param map[string]string) *Crea
 type DeleteImageOptions struct {
 	// The full IBM Cloud registry path to the image that you want to delete, including its tag. If you do not provide a
 	// specific tag, the version with the `latest` tag is removed.
-	Image *string `json:"-" validate:"required,ne="`
+	Image *string `json:"image" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -2305,7 +2305,7 @@ func (options *DeleteImageOptions) SetHeaders(param map[string]string) *DeleteIm
 // DeleteImageTagOptions : The DeleteImageTag options.
 type DeleteImageTagOptions struct {
 	// The name of the image that you want to delete, in the format &lt;REPOSITORY&gt;:&lt;TAG&gt;.
-	Image *string `json:"-" validate:"required,ne="`
+	Image *string `json:"image" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -2333,7 +2333,7 @@ func (options *DeleteImageTagOptions) SetHeaders(param map[string]string) *Delet
 // DeleteNamespaceOptions : The DeleteNamespace options.
 type DeleteNamespaceOptions struct {
 	// The name of the namespace that you want to delete.
-	Name *string `json:"-" validate:"required,ne="`
+	Name *string `json:"name" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -2380,7 +2380,7 @@ func (options *GetAuthOptions) SetHeaders(param map[string]string) *GetAuthOptio
 type GetImageManifestOptions struct {
 	// The full IBM Cloud registry path to the image that you want to inspect. Run `ibmcloud cr images` or call the `GET
 	// /images/json` endpoint to review images that are in the registry.
-	Image *string `json:"-" validate:"required,ne="`
+	Image *string `json:"image" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -2462,7 +2462,7 @@ func (options *GetQuotaOptions) SetHeaders(param map[string]string) *GetQuotaOpt
 // GetRetentionPolicyOptions : The GetRetentionPolicy options.
 type GetRetentionPolicyOptions struct {
 	// Gets the retention policy for the specified namespace.
-	Namespace *string `json:"-" validate:"required,ne="`
+	Namespace *string `json:"namespace" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -2783,7 +2783,7 @@ func UnmarshalImageInspection(m map[string]json.RawMessage, result interface{}) 
 type InspectImageOptions struct {
 	// The full IBM Cloud registry path to the image that you want to inspect. Run `ibmcloud cr images` or call the `GET
 	// /images/json` endpoint to review images that are in the registry.
-	Image *string `json:"-" validate:"required,ne="`
+	Image *string `json:"image" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -2811,7 +2811,7 @@ func (options *InspectImageOptions) SetHeaders(param map[string]string) *Inspect
 // ListDeletedImagesOptions : The ListDeletedImages options.
 type ListDeletedImagesOptions struct {
 	// Limit results to trash can images in the given namespace only.
-	Namespace *string `json:"-"`
+	Namespace *string `json:"namespace,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -2892,28 +2892,28 @@ type ListImagesOptions struct {
 	// Lists images that are stored in the specified namespace only. Query multiple namespaces by specifying this option
 	// for each namespace. If this option is not specified, images from all namespaces in the specified IBM Cloud account
 	// are listed.
-	Namespace *string `json:"-"`
+	Namespace *string `json:"namespace,omitempty"`
 
 	// Includes IBM-provided public images in the list of images. If this option is not specified, private images are
 	// listed only. If this option is specified more than once, the last parsed setting is the setting that is used.
-	IncludeIBM *bool `json:"-"`
+	IncludeIBM *bool `json:"includeIBM,omitempty"`
 
 	// Includes private images in the list of images. If this option is not specified, private images are listed. If this
 	// option is specified more than once, the last parsed setting is the setting that is used.
-	IncludePrivate *bool `json:"-"`
+	IncludePrivate *bool `json:"includePrivate,omitempty"`
 
 	// Includes tags that reference multi-architecture manifest lists in the image list. If this option is not specified,
 	// tagged manifest lists are not shown in the list. If this option is specified more than once, the last parsed setting
 	// is the setting that is used.
-	IncludeManifestLists *bool `json:"-"`
+	IncludeManifestLists *bool `json:"includeManifestLists,omitempty"`
 
 	// Displays Vulnerability Advisor status for the listed images. If this option is specified more than once, the last
 	// parsed setting is the setting that is used.
-	Vulnerabilities *bool `json:"-"`
+	Vulnerabilities *bool `json:"vulnerabilities,omitempty"`
 
 	// Lists images that are stored in the specified repository, under your namespaces. Query multiple repositories by
 	// specifying this option for each repository. If this option is not specified, images from all repos are listed.
-	Repository *string `json:"-"`
+	Repository *string `json:"repository,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3260,7 +3260,7 @@ func UnmarshalRemoteAPIImage(m map[string]json.RawMessage, result interface{}) (
 type RestoreImageOptions struct {
 	// The name of the image that you want to restore, in the format &lt;REPOSITORY&gt;:&lt;TAG&gt;. Run `ibmcloud cr
 	// trash-list` or call the `GET /trash/json` endpoint to review images that are in the trash.
-	Image *string `json:"-" validate:"required,ne="`
+	Image *string `json:"image" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3315,7 +3315,7 @@ type RestoreTagsOptions struct {
 	// The full IBM Cloud registry digest reference for the digest that you want to restore such as
 	// `icr.io/namespace/repo@sha256:a9be...`. Call the `GET /trash/json` endpoint to review digests that are in the trash
 	// and their tags in the same repository.
-	Digest *string `json:"-" validate:"required,ne="`
+	Digest *string `json:"digest" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3465,10 +3465,10 @@ func (options *SetRetentionPolicyOptions) SetHeaders(param map[string]string) *S
 type TagImageOptions struct {
 	// The name of the image that you want to create a new tag for, in the format &lt;REPOSITORY&gt;:&lt;TAG&gt;. Run
 	// `ibmcloud cr images` or call the `GET /images/json` endpoint to review images that are in the registry.
-	Fromimage *string `json:"-" validate:"required"`
+	Fromimage *string `json:"fromimage" validate:"required"`
 
 	// The new tag for the image, in the format &lt;REPOSITORY&gt;:&lt;TAG&gt;.
-	Toimage *string `json:"-" validate:"required"`
+	Toimage *string `json:"toimage" validate:"required"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3478,7 +3478,7 @@ type TagImageOptions struct {
 func (*ContainerRegistryV1) NewTagImageOptions(fromimage string, toimage string) *TagImageOptions {
 	return &TagImageOptions{
 		Fromimage: core.StringPtr(fromimage),
-		Toimage:   core.StringPtr(toimage),
+		Toimage: core.StringPtr(toimage),
 	}
 }
 

--- a/containerregistryv1/container_registry_v1_suite_test.go
+++ b/containerregistryv1/container_registry_v1_suite_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/containerregistryv1/container_registry_v1_test.go
+++ b/containerregistryv1/container_registry_v1_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -41,14 +40,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 		It(`Instantiate service client`, func() {
 			containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 				Authenticator: &core.NoAuthAuthenticator{},
-				Account:       core.StringPtr(account),
+				Account: core.StringPtr(account),
 			})
 			Expect(containerRegistryService).ToNot(BeNil())
 			Expect(serviceErr).To(BeNil())
 		})
 		It(`Instantiate service client with error: Invalid URL`, func() {
 			containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
-				URL:     "{BAD_URL_STRING",
+				URL: "{BAD_URL_STRING",
 				Account: core.StringPtr(account),
 			})
 			Expect(containerRegistryService).To(BeNil())
@@ -56,7 +55,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 		})
 		It(`Instantiate service client with error: Invalid Auth`, func() {
 			containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
-				URL:     "https://containerregistryv1/api",
+				URL: "https://containerregistryv1/api",
 				Account: core.StringPtr(account),
 				Authenticator: &core.BasicAuthenticator{
 					Username: "",
@@ -77,7 +76,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"CONTAINER_REGISTRY_URL":       "https://containerregistryv1/api",
+				"CONTAINER_REGISTRY_URL": "https://containerregistryv1/api",
 				"CONTAINER_REGISTRY_AUTH_TYPE": "noauth",
 			}
 
@@ -99,7 +98,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			It(`Create service client using external config and set url from constructor successfully`, func() {
 				SetTestEnvironment(testEnvironment)
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1UsingExternalConfig(&containerregistryv1.ContainerRegistryV1Options{
-					URL:     "https://testService/api",
+					URL: "https://testService/api",
 					Account: core.StringPtr(account),
 				})
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -135,7 +134,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"CONTAINER_REGISTRY_URL":       "https://containerregistryv1/api",
+				"CONTAINER_REGISTRY_URL": "https://containerregistryv1/api",
 				"CONTAINER_REGISTRY_AUTH_TYPE": "someOtherAuth",
 			}
 
@@ -153,12 +152,12 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"CONTAINER_REGISTRY_AUTH_TYPE": "NOAuth",
+				"CONTAINER_REGISTRY_AUTH_TYPE":   "NOAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
 			containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1UsingExternalConfig(&containerregistryv1.ContainerRegistryV1Options{
-				URL:     "{BAD_URL_STRING",
+				URL: "{BAD_URL_STRING",
 				Account: core.StringPtr(account),
 			})
 
@@ -173,6 +172,10 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 		It(`GetServiceURLForRegion(region string)`, func() {
 			var url string
 			var err error
+			url, err = containerregistryv1.GetServiceURLForRegion("global")
+			Expect(url).To(Equal("https://icr.io"))
+			Expect(err).To(BeNil())
+
 			url, err = containerregistryv1.GetServiceURLForRegion("us-south")
 			Expect(url).To(Equal("https://us.icr.io"))
 			Expect(err).To(BeNil())
@@ -209,10 +212,6 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			Expect(url).To(Equal("https://au.icr.io"))
 			Expect(err).To(BeNil())
 
-			url, err = containerregistryv1.GetServiceURLForRegion("global")
-			Expect(url).To(Equal("https://icr.io"))
-			Expect(err).To(BeNil())
-
 			url, err = containerregistryv1.GetServiceURLForRegion("jp-osa")
 			Expect(url).To(Equal("https://jp2.icr.io"))
 			Expect(err).To(BeNil())
@@ -246,14 +245,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetAuth with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -306,7 +305,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -362,7 +361,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -388,7 +387,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -422,7 +421,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -481,7 +480,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -506,7 +505,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -550,14 +549,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.URL.Query()["repository"]).To(Equal([]string{"testString"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListImages with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -622,7 +621,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -690,7 +689,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -722,7 +721,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -762,7 +761,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -805,14 +804,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke BulkDeleteImages with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -882,7 +881,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -955,7 +954,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -982,7 +981,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1024,7 +1023,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1062,14 +1061,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListImageDigests with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1135,14 +1134,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `[{"created": 7, "id": "ID", "manifestType": "ManifestType", "repoTags": {"mapKey": "anyValue"}, "size": 4}]`)
+					fmt.Fprintf(res, "%s", `[{"created": 7, "id": "ID", "manifestType": "ManifestType", "repoTags": {"anyKey": "anyValue"}, "size": 4}]`)
 				}))
 			})
 			It(`Invoke ListImageDigests successfully with retries`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1211,14 +1210,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `[{"created": 7, "id": "ID", "manifestType": "ManifestType", "repoTags": {"mapKey": "anyValue"}, "size": 4}]`)
+					fmt.Fprintf(res, "%s", `[{"created": 7, "id": "ID", "manifestType": "ManifestType", "repoTags": {"anyKey": "anyValue"}, "size": 4}]`)
 				}))
 			})
 			It(`Invoke ListImageDigests successfully`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1248,7 +1247,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1286,7 +1285,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1335,7 +1334,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1360,7 +1359,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1404,14 +1403,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke DeleteImage with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1465,7 +1464,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1522,7 +1521,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1549,7 +1548,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1591,7 +1590,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1629,14 +1628,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke InspectImage with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1683,14 +1682,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"Architecture": "Architecture", "Author": "Author", "Comment": "Comment", "Config": {"ArgsEscaped": false, "AttachStderr": true, "AttachStdin": false, "AttachStdout": true, "Cmd": ["Cmd"], "Domainname": "Domainname", "Entrypoint": ["Entrypoint"], "Env": ["Env"], "ExposedPorts": {"mapKey": {"anyKey": "anyValue"}}, "Healthcheck": {"Interval": 8, "Retries": 7, "Test": ["Test"], "Timeout": 7}, "Hostname": "Hostname", "Image": "Image", "Labels": {"mapKey": "Inner"}, "MacAddress": "MacAddress", "NetworkDisabled": false, "OnBuild": ["OnBuild"], "OpenStdin": false, "Shell": ["Shell"], "StdinOnce": false, "StopSignal": "StopSignal", "StopTimeout": 11, "Tty": false, "User": "User", "Volumes": {"mapKey": {"anyKey": "anyValue"}}, "WorkingDir": "WorkingDir"}, "Container": "Container", "ContainerConfig": {"ArgsEscaped": false, "AttachStderr": true, "AttachStdin": false, "AttachStdout": true, "Cmd": ["Cmd"], "Domainname": "Domainname", "Entrypoint": ["Entrypoint"], "Env": ["Env"], "ExposedPorts": {"mapKey": {"anyKey": "anyValue"}}, "Healthcheck": {"Interval": 8, "Retries": 7, "Test": ["Test"], "Timeout": 7}, "Hostname": "Hostname", "Image": "Image", "Labels": {"mapKey": "Inner"}, "MacAddress": "MacAddress", "NetworkDisabled": false, "OnBuild": ["OnBuild"], "OpenStdin": false, "Shell": ["Shell"], "StdinOnce": false, "StopSignal": "StopSignal", "StopTimeout": 11, "Tty": false, "User": "User", "Volumes": {"mapKey": {"anyKey": "anyValue"}}, "WorkingDir": "WorkingDir"}, "Created": "Created", "DockerVersion": "DockerVersion", "Id": "ID", "ManifestType": "ManifestType", "Os": "Os", "OsVersion": "OsVersion", "Parent": "Parent", "RootFS": {"BaseLayer": "BaseLayer", "Layers": ["Layers"], "Type": "Type"}, "Size": 4, "VirtualSize": 11}`)
+					fmt.Fprintf(res, "%s", `{"Architecture": "Architecture", "Author": "Author", "Comment": "Comment", "Config": {"ArgsEscaped": false, "AttachStderr": true, "AttachStdin": false, "AttachStdout": true, "Cmd": ["Cmd"], "Domainname": "Domainname", "Entrypoint": ["Entrypoint"], "Env": ["Env"], "ExposedPorts": {"anyKey": "anyValue"}, "Healthcheck": {"Interval": 8, "Retries": 7, "Test": ["Test"], "Timeout": 7}, "Hostname": "Hostname", "Image": "Image", "Labels": {"mapKey": "Inner"}, "MacAddress": "MacAddress", "NetworkDisabled": false, "OnBuild": ["OnBuild"], "OpenStdin": false, "Shell": ["Shell"], "StdinOnce": false, "StopSignal": "StopSignal", "StopTimeout": 11, "Tty": false, "User": "User", "Volumes": {"anyKey": "anyValue"}, "WorkingDir": "WorkingDir"}, "Container": "Container", "ContainerConfig": {"ArgsEscaped": false, "AttachStderr": true, "AttachStdin": false, "AttachStdout": true, "Cmd": ["Cmd"], "Domainname": "Domainname", "Entrypoint": ["Entrypoint"], "Env": ["Env"], "ExposedPorts": {"anyKey": "anyValue"}, "Healthcheck": {"Interval": 8, "Retries": 7, "Test": ["Test"], "Timeout": 7}, "Hostname": "Hostname", "Image": "Image", "Labels": {"mapKey": "Inner"}, "MacAddress": "MacAddress", "NetworkDisabled": false, "OnBuild": ["OnBuild"], "OpenStdin": false, "Shell": ["Shell"], "StdinOnce": false, "StopSignal": "StopSignal", "StopTimeout": 11, "Tty": false, "User": "User", "Volumes": {"anyKey": "anyValue"}, "WorkingDir": "WorkingDir"}, "Created": "Created", "DockerVersion": "DockerVersion", "Id": "ID", "ManifestType": "ManifestType", "Os": "Os", "OsVersion": "OsVersion", "Parent": "Parent", "RootFS": {"BaseLayer": "BaseLayer", "Layers": ["Layers"], "Type": "Type"}, "Size": 4, "VirtualSize": 11}`)
 				}))
 			})
 			It(`Invoke InspectImage successfully with retries`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1740,14 +1739,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"Architecture": "Architecture", "Author": "Author", "Comment": "Comment", "Config": {"ArgsEscaped": false, "AttachStderr": true, "AttachStdin": false, "AttachStdout": true, "Cmd": ["Cmd"], "Domainname": "Domainname", "Entrypoint": ["Entrypoint"], "Env": ["Env"], "ExposedPorts": {"mapKey": {"anyKey": "anyValue"}}, "Healthcheck": {"Interval": 8, "Retries": 7, "Test": ["Test"], "Timeout": 7}, "Hostname": "Hostname", "Image": "Image", "Labels": {"mapKey": "Inner"}, "MacAddress": "MacAddress", "NetworkDisabled": false, "OnBuild": ["OnBuild"], "OpenStdin": false, "Shell": ["Shell"], "StdinOnce": false, "StopSignal": "StopSignal", "StopTimeout": 11, "Tty": false, "User": "User", "Volumes": {"mapKey": {"anyKey": "anyValue"}}, "WorkingDir": "WorkingDir"}, "Container": "Container", "ContainerConfig": {"ArgsEscaped": false, "AttachStderr": true, "AttachStdin": false, "AttachStdout": true, "Cmd": ["Cmd"], "Domainname": "Domainname", "Entrypoint": ["Entrypoint"], "Env": ["Env"], "ExposedPorts": {"mapKey": {"anyKey": "anyValue"}}, "Healthcheck": {"Interval": 8, "Retries": 7, "Test": ["Test"], "Timeout": 7}, "Hostname": "Hostname", "Image": "Image", "Labels": {"mapKey": "Inner"}, "MacAddress": "MacAddress", "NetworkDisabled": false, "OnBuild": ["OnBuild"], "OpenStdin": false, "Shell": ["Shell"], "StdinOnce": false, "StopSignal": "StopSignal", "StopTimeout": 11, "Tty": false, "User": "User", "Volumes": {"mapKey": {"anyKey": "anyValue"}}, "WorkingDir": "WorkingDir"}, "Created": "Created", "DockerVersion": "DockerVersion", "Id": "ID", "ManifestType": "ManifestType", "Os": "Os", "OsVersion": "OsVersion", "Parent": "Parent", "RootFS": {"BaseLayer": "BaseLayer", "Layers": ["Layers"], "Type": "Type"}, "Size": 4, "VirtualSize": 11}`)
+					fmt.Fprintf(res, "%s", `{"Architecture": "Architecture", "Author": "Author", "Comment": "Comment", "Config": {"ArgsEscaped": false, "AttachStderr": true, "AttachStdin": false, "AttachStdout": true, "Cmd": ["Cmd"], "Domainname": "Domainname", "Entrypoint": ["Entrypoint"], "Env": ["Env"], "ExposedPorts": {"anyKey": "anyValue"}, "Healthcheck": {"Interval": 8, "Retries": 7, "Test": ["Test"], "Timeout": 7}, "Hostname": "Hostname", "Image": "Image", "Labels": {"mapKey": "Inner"}, "MacAddress": "MacAddress", "NetworkDisabled": false, "OnBuild": ["OnBuild"], "OpenStdin": false, "Shell": ["Shell"], "StdinOnce": false, "StopSignal": "StopSignal", "StopTimeout": 11, "Tty": false, "User": "User", "Volumes": {"anyKey": "anyValue"}, "WorkingDir": "WorkingDir"}, "Container": "Container", "ContainerConfig": {"ArgsEscaped": false, "AttachStderr": true, "AttachStdin": false, "AttachStdout": true, "Cmd": ["Cmd"], "Domainname": "Domainname", "Entrypoint": ["Entrypoint"], "Env": ["Env"], "ExposedPorts": {"anyKey": "anyValue"}, "Healthcheck": {"Interval": 8, "Retries": 7, "Test": ["Test"], "Timeout": 7}, "Hostname": "Hostname", "Image": "Image", "Labels": {"mapKey": "Inner"}, "MacAddress": "MacAddress", "NetworkDisabled": false, "OnBuild": ["OnBuild"], "OpenStdin": false, "Shell": ["Shell"], "StdinOnce": false, "StopSignal": "StopSignal", "StopTimeout": 11, "Tty": false, "User": "User", "Volumes": {"anyKey": "anyValue"}, "WorkingDir": "WorkingDir"}, "Created": "Created", "DockerVersion": "DockerVersion", "Id": "ID", "ManifestType": "ManifestType", "Os": "Os", "OsVersion": "OsVersion", "Parent": "Parent", "RootFS": {"BaseLayer": "BaseLayer", "Layers": ["Layers"], "Type": "Type"}, "Size": 4, "VirtualSize": 11}`)
 				}))
 			})
 			It(`Invoke InspectImage successfully`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1774,7 +1773,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1816,7 +1815,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1859,14 +1858,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"mapKey": "anyValue"}`)
+					fmt.Fprintf(res, "%s", `{"anyKey": "anyValue"}`)
 				}))
 			})
 			It(`Invoke GetImageManifest successfully with retries`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1916,14 +1915,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"mapKey": "anyValue"}`)
+					fmt.Fprintf(res, "%s", `{"anyKey": "anyValue"}`)
 				}))
 			})
 			It(`Invoke GetImageManifest successfully`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1950,7 +1949,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -1992,7 +1991,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2040,7 +2039,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2094,7 +2093,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2120,7 +2119,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2154,7 +2153,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2203,7 +2202,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2259,7 +2258,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2285,7 +2284,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2319,7 +2318,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2356,14 +2355,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListNamespaceDetails with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2416,7 +2415,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2472,7 +2471,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2498,7 +2497,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2532,7 +2531,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2571,14 +2570,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["X-Auth-Resource-Group"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke CreateNamespace with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2635,7 +2634,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2695,7 +2694,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2723,7 +2722,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2766,7 +2765,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2807,14 +2806,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["X-Auth-Resource-Group"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke AssignNamespace with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2871,7 +2870,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2931,7 +2930,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -2959,7 +2958,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3002,7 +3001,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3047,7 +3046,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3071,7 +3070,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3114,14 +3113,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetPlans with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3174,7 +3173,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3230,7 +3229,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3256,7 +3255,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3290,7 +3289,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3349,7 +3348,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3373,7 +3372,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3410,14 +3409,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetQuota with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3470,7 +3469,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3526,7 +3525,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3552,7 +3551,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3586,7 +3585,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3645,7 +3644,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3670,7 +3669,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3708,14 +3707,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListRetentionPolicies with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3768,7 +3767,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3824,7 +3823,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3850,7 +3849,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3884,7 +3883,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3943,7 +3942,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -3969,7 +3968,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4014,14 +4013,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke AnalyzeRetentionPolicy with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4093,7 +4092,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4168,7 +4167,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4197,7 +4196,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4241,7 +4240,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4281,14 +4280,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetRetentionPolicy with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4342,7 +4341,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4399,7 +4398,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4426,7 +4425,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4468,7 +4467,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4506,14 +4505,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetSettings with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4566,7 +4565,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4622,7 +4621,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4648,7 +4647,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4682,7 +4681,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4741,7 +4740,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4765,7 +4764,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4802,14 +4801,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke DeleteImageTag with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4863,7 +4862,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4920,7 +4919,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4947,7 +4946,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -4989,7 +4988,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5028,14 +5027,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.URL.Query()["namespace"]).To(Equal([]string{"testString"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListDeletedImages with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5090,7 +5089,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5148,7 +5147,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5175,7 +5174,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5210,7 +5209,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5248,14 +5247,14 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 					Expect(req.Header["Account"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke RestoreTags with error: Operation response processing error`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5309,7 +5308,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5366,7 +5365,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5393,7 +5392,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5435,7 +5434,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5479,7 +5478,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5503,7 +5502,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 				containerRegistryService, serviceErr := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
-					Account:       core.StringPtr(account),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(containerRegistryService).ToNot(BeNil())
@@ -5537,7 +5536,7 @@ var _ = Describe(`ContainerRegistryV1`, func() {
 			containerRegistryService, _ := containerregistryv1.NewContainerRegistryV1(&containerregistryv1.ContainerRegistryV1Options{
 				URL:           "http://containerregistryv1modelgenerator.com",
 				Authenticator: &core.NoAuthAuthenticator{},
-				Account:       core.StringPtr(account),
+				Account: core.StringPtr(account),
 			})
 			It(`Invoke NewAnalyzeRetentionPolicyOptions successfully`, func() {
 				// Construct an instance of the AnalyzeRetentionPolicyOptions model
@@ -5882,7 +5881,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/vulnerabilityadvisorv4/vulnerability_advisor_v4.go
+++ b/vulnerabilityadvisorv4/vulnerability_advisor_v4.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.38.1-1037b405-20210908-184149
+ * IBM OpenAPI SDK Code Generator Version: 3.72.0-5d70f2bb-20230511-203609
  */
 
-// Package vulnerabilityadvisorv3 : Operations and models for the VulnerabilityAdvisorV3 service
-package vulnerabilityadvisorv3
+// Package vulnerabilityadvisorv4 : Operations and models for the VulnerabilityAdvisorV4 service
+package vulnerabilityadvisorv4
 
 import (
 	"context"
@@ -33,40 +33,40 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 )
 
-// VulnerabilityAdvisorV3 : Management interface of Vulnerability Advisor for IBM Cloud Container Registry
+// VulnerabilityAdvisorV4 : Management interface of Vulnerability Advisor for IBM Cloud Container Registry
 //
-// API Version: 3.0.0
-type VulnerabilityAdvisorV3 struct {
+// API Version: 4.0.0
+type VulnerabilityAdvisorV4 struct {
 	Service *core.BaseService
-
-	// The unique ID for your IBM Cloud account. Run 'ibmcloud cr info' to get the ID of the target account.
-	Account *string
 
 	// The preferred language code for this request.
 	AcceptLanguage *string
+
+	// The unique ID for your IBM Cloud account. Run 'ibmcloud cr info' to get the ID of the target account.
+	Account *string
 }
 
 // DefaultServiceURL is the default URL to make service requests to.
-const DefaultServiceURL = "https://us.icr.io"
+const DefaultServiceURL = "https://icr.io"
 
 // DefaultServiceName is the default key used to find external configuration information.
 const DefaultServiceName = "vulnerability_advisor"
 
-// VulnerabilityAdvisorV3Options : Service options
-type VulnerabilityAdvisorV3Options struct {
+// VulnerabilityAdvisorV4Options : Service options
+type VulnerabilityAdvisorV4Options struct {
 	ServiceName   string
 	URL           string
 	Authenticator core.Authenticator
 
+	// The preferred language code for this request.
+	AcceptLanguage *string 
+
 	// The unique ID for your IBM Cloud account. Run 'ibmcloud cr info' to get the ID of the target account.
 	Account *string `validate:"required"`
-
-	// The preferred language code for this request.
-	AcceptLanguage *string
 }
 
-// NewVulnerabilityAdvisorV3UsingExternalConfig : constructs an instance of VulnerabilityAdvisorV3 with passed in options and external configuration.
-func NewVulnerabilityAdvisorV3UsingExternalConfig(options *VulnerabilityAdvisorV3Options) (vulnerabilityAdvisor *VulnerabilityAdvisorV3, err error) {
+// NewVulnerabilityAdvisorV4UsingExternalConfig : constructs an instance of VulnerabilityAdvisorV4 with passed in options and external configuration.
+func NewVulnerabilityAdvisorV4UsingExternalConfig(options *VulnerabilityAdvisorV4Options) (vulnerabilityAdvisor *VulnerabilityAdvisorV4, err error) {
 	if options.ServiceName == "" {
 		options.ServiceName = DefaultServiceName
 	}
@@ -78,7 +78,7 @@ func NewVulnerabilityAdvisorV3UsingExternalConfig(options *VulnerabilityAdvisorV
 		}
 	}
 
-	vulnerabilityAdvisor, err = NewVulnerabilityAdvisorV3(options)
+	vulnerabilityAdvisor, err = NewVulnerabilityAdvisorV4(options)
 	if err != nil {
 		return
 	}
@@ -94,8 +94,8 @@ func NewVulnerabilityAdvisorV3UsingExternalConfig(options *VulnerabilityAdvisorV
 	return
 }
 
-// NewVulnerabilityAdvisorV3 : constructs an instance of VulnerabilityAdvisorV3 with passed in options.
-func NewVulnerabilityAdvisorV3(options *VulnerabilityAdvisorV3Options) (service *VulnerabilityAdvisorV3, err error) {
+// NewVulnerabilityAdvisorV4 : constructs an instance of VulnerabilityAdvisorV4 with passed in options.
+func NewVulnerabilityAdvisorV4(options *VulnerabilityAdvisorV4Options) (service *VulnerabilityAdvisorV4, err error) {
 	serviceOptions := &core.ServiceOptions{
 		URL:           DefaultServiceURL,
 		Authenticator: options.Authenticator,
@@ -118,10 +118,10 @@ func NewVulnerabilityAdvisorV3(options *VulnerabilityAdvisorV3Options) (service 
 		}
 	}
 
-	service = &VulnerabilityAdvisorV3{
-		Service:        baseService,
-		Account:        options.Account,
+	service = &VulnerabilityAdvisorV4{
+		Service: baseService,
 		AcceptLanguage: options.AcceptLanguage,
+		Account: options.Account,
 	}
 
 	return
@@ -130,17 +130,19 @@ func NewVulnerabilityAdvisorV3(options *VulnerabilityAdvisorV3Options) (service 
 // GetServiceURLForRegion returns the service URL to be used for the specified region
 func GetServiceURLForRegion(region string) (string, error) {
 	var endpoints = map[string]string{
-		"us-south":   "https://us.icr.io",  // us-south
-		"uk-south":   "https://uk.icr.io",  // uk-south
-		"eu-gb":      "https://uk.icr.io",  // eu-gb
-		"eu-central": "https://de.icr.io",  // eu-central
-		"eu-de":      "https://de.icr.io",  // eu-de
-		"ap-north":   "https://jp.icr.io",  // ap-north
-		"jp-tok":     "https://jp.icr.io",  // jp-tok
-		"ap-south":   "https://au.icr.io",  // ap-south
-		"au-syd":     "https://au.icr.io",  // au-syd
-		"global":     "https://icr.io",     // global
-		"jp-osa":     "https://jp2.icr.io", // jp-osa
+		"global": "https://icr.io", // global
+		"us-south": "https://us.icr.io", // us-south
+		"uk-south": "https://uk.icr.io", // uk-south
+		"eu-gb": "https://uk.icr.io", // eu-gb
+		"eu-central": "https://de.icr.io", // eu-central
+		"eu-de": "https://de.icr.io", // eu-de
+		"ap-north": "https://jp.icr.io", // ap-north
+		"jp-tok": "https://jp.icr.io", // jp-tok
+		"ap-south": "https://au.icr.io", // ap-south
+		"au-syd": "https://au.icr.io", // au-syd
+		"jp-osa": "https://jp2.icr.io", // jp-osa
+		"ca-tor": "https://ca.icr.io", // ca-tor
+		"br-sao": "https://br.icr.io", // br-sao
 	}
 
 	if url, ok := endpoints[region]; ok {
@@ -150,7 +152,7 @@ func GetServiceURLForRegion(region string) (string, error) {
 }
 
 // Clone makes a copy of "vulnerabilityAdvisor" suitable for processing requests.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) Clone() *VulnerabilityAdvisorV3 {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) Clone() *VulnerabilityAdvisorV4 {
 	if core.IsNil(vulnerabilityAdvisor) {
 		return nil
 	}
@@ -160,49 +162,49 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) Clone() *VulnerabilityAdviso
 }
 
 // SetServiceURL sets the service URL
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) SetServiceURL(url string) error {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) SetServiceURL(url string) error {
 	return vulnerabilityAdvisor.Service.SetServiceURL(url)
 }
 
 // GetServiceURL returns the service URL
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetServiceURL() string {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) GetServiceURL() string {
 	return vulnerabilityAdvisor.Service.GetServiceURL()
 }
 
 // SetDefaultHeaders sets HTTP headers to be sent in every request
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) SetDefaultHeaders(headers http.Header) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) SetDefaultHeaders(headers http.Header) {
 	vulnerabilityAdvisor.Service.SetDefaultHeaders(headers)
 }
 
 // SetEnableGzipCompression sets the service's EnableGzipCompression field
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) SetEnableGzipCompression(enableGzip bool) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) SetEnableGzipCompression(enableGzip bool) {
 	vulnerabilityAdvisor.Service.SetEnableGzipCompression(enableGzip)
 }
 
 // GetEnableGzipCompression returns the service's EnableGzipCompression field
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetEnableGzipCompression() bool {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) GetEnableGzipCompression() bool {
 	return vulnerabilityAdvisor.Service.GetEnableGzipCompression()
 }
 
 // EnableRetries enables automatic retries for requests invoked for this service instance.
 // If either parameter is specified as 0, then a default value is used instead.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) EnableRetries(maxRetries int, maxRetryInterval time.Duration) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) EnableRetries(maxRetries int, maxRetryInterval time.Duration) {
 	vulnerabilityAdvisor.Service.EnableRetries(maxRetries, maxRetryInterval)
 }
 
 // DisableRetries disables automatic retries for requests invoked for this service instance.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DisableRetries() {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) DisableRetries() {
 	vulnerabilityAdvisor.Service.DisableRetries()
 }
 
 // AccountReportQueryPath : Get the vulnerability assessment for all images
 // Get the vulnerability assessment for the list of registry images that belong to a specific account.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) AccountReportQueryPath(accountReportQueryPathOptions *AccountReportQueryPathOptions) (result *ScanReportList, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) AccountReportQueryPath(accountReportQueryPathOptions *AccountReportQueryPathOptions) (result *ScanReportList, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.AccountReportQueryPathWithContext(context.Background(), accountReportQueryPathOptions)
 }
 
 // AccountReportQueryPathWithContext is an alternate form of the AccountReportQueryPath method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) AccountReportQueryPathWithContext(ctx context.Context, accountReportQueryPathOptions *AccountReportQueryPathOptions) (result *ScanReportList, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) AccountReportQueryPathWithContext(ctx context.Context, accountReportQueryPathOptions *AccountReportQueryPathOptions) (result *ScanReportList, response *core.DetailedResponse, err error) {
 	err = core.ValidateStruct(accountReportQueryPathOptions, "accountReportQueryPathOptions")
 	if err != nil {
 		return
@@ -211,7 +213,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) AccountReportQueryPathWithCo
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/report/account`, nil)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/report/account`, nil)
 	if err != nil {
 		return
 	}
@@ -220,7 +222,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) AccountReportQueryPathWithCo
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "AccountReportQueryPath")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "AccountReportQueryPath")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -265,12 +267,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) AccountReportQueryPathWithCo
 
 // AccountStatusQueryPath : Get vulnerability assessment status for all images
 // Get the vulnerability assessment status for the list of registry images that belong to a specific account.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) AccountStatusQueryPath(accountStatusQueryPathOptions *AccountStatusQueryPathOptions) (result *ScanreportImageSummaryList, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) AccountStatusQueryPath(accountStatusQueryPathOptions *AccountStatusQueryPathOptions) (result *ScanreportImageSummaryList, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.AccountStatusQueryPathWithContext(context.Background(), accountStatusQueryPathOptions)
 }
 
 // AccountStatusQueryPathWithContext is an alternate form of the AccountStatusQueryPath method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) AccountStatusQueryPathWithContext(ctx context.Context, accountStatusQueryPathOptions *AccountStatusQueryPathOptions) (result *ScanreportImageSummaryList, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) AccountStatusQueryPathWithContext(ctx context.Context, accountStatusQueryPathOptions *AccountStatusQueryPathOptions) (result *ScanreportImageSummaryList, response *core.DetailedResponse, err error) {
 	err = core.ValidateStruct(accountStatusQueryPathOptions, "accountStatusQueryPathOptions")
 	if err != nil {
 		return
@@ -279,7 +281,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) AccountStatusQueryPathWithCo
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/report/account/status`, nil)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/report/account/status`, nil)
 	if err != nil {
 		return
 	}
@@ -288,7 +290,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) AccountStatusQueryPathWithCo
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "AccountStatusQueryPath")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "AccountStatusQueryPath")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -333,12 +335,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) AccountStatusQueryPathWithCo
 
 // ImageReportQueryPath : Get vulnerability assessment
 // Get the vulnerability assessment for a registry image.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ImageReportQueryPath(imageReportQueryPathOptions *ImageReportQueryPathOptions) (result *ScanReport, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ImageReportQueryPath(imageReportQueryPathOptions *ImageReportQueryPathOptions) (result *ScanReport, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.ImageReportQueryPathWithContext(context.Background(), imageReportQueryPathOptions)
 }
 
 // ImageReportQueryPathWithContext is an alternate form of the ImageReportQueryPath method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ImageReportQueryPathWithContext(ctx context.Context, imageReportQueryPathOptions *ImageReportQueryPathOptions) (result *ScanReport, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ImageReportQueryPathWithContext(ctx context.Context, imageReportQueryPathOptions *ImageReportQueryPathOptions) (result *ScanReport, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(imageReportQueryPathOptions, "imageReportQueryPathOptions cannot be nil")
 	if err != nil {
 		return
@@ -355,7 +357,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ImageReportQueryPathWithCont
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/report/image/{name}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/report/image/{name}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -364,7 +366,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ImageReportQueryPathWithCont
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "ImageReportQueryPath")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "ImageReportQueryPath")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -397,14 +399,14 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ImageReportQueryPathWithCont
 	return
 }
 
-// ImageStatusQueryPath : Get vulnerability status
+// ImageStatusQueryPath : Get vulnerability assessment status
 // Get the overall vulnerability status for a registry image.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ImageStatusQueryPath(imageStatusQueryPathOptions *ImageStatusQueryPathOptions) (result *ScanreportSummary, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ImageStatusQueryPath(imageStatusQueryPathOptions *ImageStatusQueryPathOptions) (result *ScanreportSummary, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.ImageStatusQueryPathWithContext(context.Background(), imageStatusQueryPathOptions)
 }
 
 // ImageStatusQueryPathWithContext is an alternate form of the ImageStatusQueryPath method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ImageStatusQueryPathWithContext(ctx context.Context, imageStatusQueryPathOptions *ImageStatusQueryPathOptions) (result *ScanreportSummary, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ImageStatusQueryPathWithContext(ctx context.Context, imageStatusQueryPathOptions *ImageStatusQueryPathOptions) (result *ScanreportSummary, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(imageStatusQueryPathOptions, "imageStatusQueryPathOptions cannot be nil")
 	if err != nil {
 		return
@@ -421,7 +423,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ImageStatusQueryPathWithCont
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/report/image/status/{name}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/report/image/status/{name}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -430,7 +432,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ImageStatusQueryPathWithCont
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "ImageStatusQueryPath")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "ImageStatusQueryPath")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -465,12 +467,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ImageStatusQueryPathWithCont
 
 // ListExemptionAccount : List account level exemptions
 // List the exemptions that are specified with account level scope.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListExemptionAccount(listExemptionAccountOptions *ListExemptionAccountOptions) (result []Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ListExemptionAccount(listExemptionAccountOptions *ListExemptionAccountOptions) (result []Exemption, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.ListExemptionAccountWithContext(context.Background(), listExemptionAccountOptions)
 }
 
 // ListExemptionAccountWithContext is an alternate form of the ListExemptionAccount method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListExemptionAccountWithContext(ctx context.Context, listExemptionAccountOptions *ListExemptionAccountOptions) (result []Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ListExemptionAccountWithContext(ctx context.Context, listExemptionAccountOptions *ListExemptionAccountOptions) (result []Exemption, response *core.DetailedResponse, err error) {
 	err = core.ValidateStruct(listExemptionAccountOptions, "listExemptionAccountOptions")
 	if err != nil {
 		return
@@ -479,7 +481,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListExemptionAccountWithCont
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exempt/image`, nil)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exempt/image`, nil)
 	if err != nil {
 		return
 	}
@@ -488,7 +490,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListExemptionAccountWithCont
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "ListExemptionAccount")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "ListExemptionAccount")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -523,12 +525,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListExemptionAccountWithCont
 
 // GetExemptionAccount : Get an account level exemption
 // Get details of an exemption that is specified with account level scope.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetExemptionAccount(getExemptionAccountOptions *GetExemptionAccountOptions) (result *Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) GetExemptionAccount(getExemptionAccountOptions *GetExemptionAccountOptions) (result *Exemption, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.GetExemptionAccountWithContext(context.Background(), getExemptionAccountOptions)
 }
 
 // GetExemptionAccountWithContext is an alternate form of the GetExemptionAccount method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetExemptionAccountWithContext(ctx context.Context, getExemptionAccountOptions *GetExemptionAccountOptions) (result *Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) GetExemptionAccountWithContext(ctx context.Context, getExemptionAccountOptions *GetExemptionAccountOptions) (result *Exemption, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(getExemptionAccountOptions, "getExemptionAccountOptions cannot be nil")
 	if err != nil {
 		return
@@ -540,13 +542,13 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetExemptionAccountWithConte
 
 	pathParamsMap := map[string]string{
 		"issueType": *getExemptionAccountOptions.IssueType,
-		"issueID":   *getExemptionAccountOptions.IssueID,
+		"issueID": *getExemptionAccountOptions.IssueID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exempt/image/issue/{issueType}/{issueID}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exempt/image/issue/{issueType}/{issueID}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -555,7 +557,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetExemptionAccountWithConte
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "GetExemptionAccount")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "GetExemptionAccount")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -590,12 +592,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetExemptionAccountWithConte
 
 // CreateExemptionAccount : Create or update an account level exemption
 // Create or update an exemption that is specified with account level scope.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) CreateExemptionAccount(createExemptionAccountOptions *CreateExemptionAccountOptions) (result *Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) CreateExemptionAccount(createExemptionAccountOptions *CreateExemptionAccountOptions) (result *Exemption, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.CreateExemptionAccountWithContext(context.Background(), createExemptionAccountOptions)
 }
 
 // CreateExemptionAccountWithContext is an alternate form of the CreateExemptionAccount method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) CreateExemptionAccountWithContext(ctx context.Context, createExemptionAccountOptions *CreateExemptionAccountOptions) (result *Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) CreateExemptionAccountWithContext(ctx context.Context, createExemptionAccountOptions *CreateExemptionAccountOptions) (result *Exemption, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(createExemptionAccountOptions, "createExemptionAccountOptions cannot be nil")
 	if err != nil {
 		return
@@ -607,13 +609,13 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) CreateExemptionAccountWithCo
 
 	pathParamsMap := map[string]string{
 		"issueType": *createExemptionAccountOptions.IssueType,
-		"issueID":   *createExemptionAccountOptions.IssueID,
+		"issueID": *createExemptionAccountOptions.IssueID,
 	}
 
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exempt/image/issue/{issueType}/{issueID}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exempt/image/issue/{issueType}/{issueID}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -622,7 +624,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) CreateExemptionAccountWithCo
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "CreateExemptionAccount")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "CreateExemptionAccount")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -657,12 +659,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) CreateExemptionAccountWithCo
 
 // DeleteExemptionAccount : Delete an account level exemption
 // Delete an exemption that is specified with account level scope.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DeleteExemptionAccount(deleteExemptionAccountOptions *DeleteExemptionAccountOptions) (response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) DeleteExemptionAccount(deleteExemptionAccountOptions *DeleteExemptionAccountOptions) (response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.DeleteExemptionAccountWithContext(context.Background(), deleteExemptionAccountOptions)
 }
 
 // DeleteExemptionAccountWithContext is an alternate form of the DeleteExemptionAccount method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DeleteExemptionAccountWithContext(ctx context.Context, deleteExemptionAccountOptions *DeleteExemptionAccountOptions) (response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) DeleteExemptionAccountWithContext(ctx context.Context, deleteExemptionAccountOptions *DeleteExemptionAccountOptions) (response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(deleteExemptionAccountOptions, "deleteExemptionAccountOptions cannot be nil")
 	if err != nil {
 		return
@@ -674,13 +676,13 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DeleteExemptionAccountWithCo
 
 	pathParamsMap := map[string]string{
 		"issueType": *deleteExemptionAccountOptions.IssueType,
-		"issueID":   *deleteExemptionAccountOptions.IssueID,
+		"issueID": *deleteExemptionAccountOptions.IssueID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exempt/image/issue/{issueType}/{issueID}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exempt/image/issue/{issueType}/{issueID}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -689,7 +691,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DeleteExemptionAccountWithCo
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "DeleteExemptionAccount")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "DeleteExemptionAccount")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -712,12 +714,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DeleteExemptionAccountWithCo
 
 // ListExemptionResource : List resource exemptions
 // List the exemptions that are specified for a resource (account, registry namespace, repository, or image).
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListExemptionResource(listExemptionResourceOptions *ListExemptionResourceOptions) (result []Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ListExemptionResource(listExemptionResourceOptions *ListExemptionResourceOptions) (result []Exemption, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.ListExemptionResourceWithContext(context.Background(), listExemptionResourceOptions)
 }
 
 // ListExemptionResourceWithContext is an alternate form of the ListExemptionResource method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListExemptionResourceWithContext(ctx context.Context, listExemptionResourceOptions *ListExemptionResourceOptions) (result []Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ListExemptionResourceWithContext(ctx context.Context, listExemptionResourceOptions *ListExemptionResourceOptions) (result []Exemption, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(listExemptionResourceOptions, "listExemptionResourceOptions cannot be nil")
 	if err != nil {
 		return
@@ -734,7 +736,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListExemptionResourceWithCon
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exempt/image/{resource}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exempt/image/{resource}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -743,7 +745,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListExemptionResourceWithCon
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "ListExemptionResource")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "ListExemptionResource")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -778,12 +780,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListExemptionResourceWithCon
 
 // GetExemptionResource : Get details of a resource exemption
 // Get an exemption that is specified for a resource (account, registry namespace, repository, or image).
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetExemptionResource(getExemptionResourceOptions *GetExemptionResourceOptions) (result *Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) GetExemptionResource(getExemptionResourceOptions *GetExemptionResourceOptions) (result *Exemption, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.GetExemptionResourceWithContext(context.Background(), getExemptionResourceOptions)
 }
 
 // GetExemptionResourceWithContext is an alternate form of the GetExemptionResource method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetExemptionResourceWithContext(ctx context.Context, getExemptionResourceOptions *GetExemptionResourceOptions) (result *Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) GetExemptionResourceWithContext(ctx context.Context, getExemptionResourceOptions *GetExemptionResourceOptions) (result *Exemption, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(getExemptionResourceOptions, "getExemptionResourceOptions cannot be nil")
 	if err != nil {
 		return
@@ -794,15 +796,15 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetExemptionResourceWithCont
 	}
 
 	pathParamsMap := map[string]string{
-		"resource":  *getExemptionResourceOptions.Resource,
+		"resource": *getExemptionResourceOptions.Resource,
 		"issueType": *getExemptionResourceOptions.IssueType,
-		"issueID":   *getExemptionResourceOptions.IssueID,
+		"issueID": *getExemptionResourceOptions.IssueID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exempt/image/{resource}/issue/{issueType}/{issueID}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exempt/image/{resource}/issue/{issueType}/{issueID}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -811,7 +813,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetExemptionResourceWithCont
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "GetExemptionResource")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "GetExemptionResource")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -846,12 +848,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) GetExemptionResourceWithCont
 
 // CreateExemptionResource : Create or update a resource exemption
 // Create or update an exemption that is specified for a resource (account, registry namespace, repository, or image).
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) CreateExemptionResource(createExemptionResourceOptions *CreateExemptionResourceOptions) (result *Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) CreateExemptionResource(createExemptionResourceOptions *CreateExemptionResourceOptions) (result *Exemption, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.CreateExemptionResourceWithContext(context.Background(), createExemptionResourceOptions)
 }
 
 // CreateExemptionResourceWithContext is an alternate form of the CreateExemptionResource method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) CreateExemptionResourceWithContext(ctx context.Context, createExemptionResourceOptions *CreateExemptionResourceOptions) (result *Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) CreateExemptionResourceWithContext(ctx context.Context, createExemptionResourceOptions *CreateExemptionResourceOptions) (result *Exemption, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(createExemptionResourceOptions, "createExemptionResourceOptions cannot be nil")
 	if err != nil {
 		return
@@ -862,15 +864,15 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) CreateExemptionResourceWithC
 	}
 
 	pathParamsMap := map[string]string{
-		"resource":  *createExemptionResourceOptions.Resource,
+		"resource": *createExemptionResourceOptions.Resource,
 		"issueType": *createExemptionResourceOptions.IssueType,
-		"issueID":   *createExemptionResourceOptions.IssueID,
+		"issueID": *createExemptionResourceOptions.IssueID,
 	}
 
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exempt/image/{resource}/issue/{issueType}/{issueID}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exempt/image/{resource}/issue/{issueType}/{issueID}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -879,7 +881,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) CreateExemptionResourceWithC
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "CreateExemptionResource")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "CreateExemptionResource")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -914,12 +916,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) CreateExemptionResourceWithC
 
 // DeleteExemptionResource : Delete a resource exemption
 // Delete an exemption that is specified for a resource (account, registry namespace, repository, or image).
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DeleteExemptionResource(deleteExemptionResourceOptions *DeleteExemptionResourceOptions) (response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) DeleteExemptionResource(deleteExemptionResourceOptions *DeleteExemptionResourceOptions) (response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.DeleteExemptionResourceWithContext(context.Background(), deleteExemptionResourceOptions)
 }
 
 // DeleteExemptionResourceWithContext is an alternate form of the DeleteExemptionResource method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DeleteExemptionResourceWithContext(ctx context.Context, deleteExemptionResourceOptions *DeleteExemptionResourceOptions) (response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) DeleteExemptionResourceWithContext(ctx context.Context, deleteExemptionResourceOptions *DeleteExemptionResourceOptions) (response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(deleteExemptionResourceOptions, "deleteExemptionResourceOptions cannot be nil")
 	if err != nil {
 		return
@@ -930,15 +932,15 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DeleteExemptionResourceWithC
 	}
 
 	pathParamsMap := map[string]string{
-		"resource":  *deleteExemptionResourceOptions.Resource,
+		"resource": *deleteExemptionResourceOptions.Resource,
 		"issueType": *deleteExemptionResourceOptions.IssueType,
-		"issueID":   *deleteExemptionResourceOptions.IssueID,
+		"issueID": *deleteExemptionResourceOptions.IssueID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exempt/image/{resource}/issue/{issueType}/{issueID}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exempt/image/{resource}/issue/{issueType}/{issueID}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -947,7 +949,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DeleteExemptionResourceWithC
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "DeleteExemptionResource")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "DeleteExemptionResource")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -970,12 +972,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) DeleteExemptionResourceWithC
 
 // ExemptHandler : List the types of exemption
 // List the types of exemption.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ExemptHandler(exemptHandlerOptions *ExemptHandlerOptions) (result []ExemptionTypeInfo, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ExemptHandler(exemptHandlerOptions *ExemptHandlerOptions) (result []ExemptionTypeInfo, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.ExemptHandlerWithContext(context.Background(), exemptHandlerOptions)
 }
 
 // ExemptHandlerWithContext is an alternate form of the ExemptHandler method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ExemptHandlerWithContext(ctx context.Context, exemptHandlerOptions *ExemptHandlerOptions) (result []ExemptionTypeInfo, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ExemptHandlerWithContext(ctx context.Context, exemptHandlerOptions *ExemptHandlerOptions) (result []ExemptionTypeInfo, response *core.DetailedResponse, err error) {
 	err = core.ValidateStruct(exemptHandlerOptions, "exemptHandlerOptions")
 	if err != nil {
 		return
@@ -984,7 +986,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ExemptHandlerWithContext(ctx
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exempt/types`, nil)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exempt/types`, nil)
 	if err != nil {
 		return
 	}
@@ -993,7 +995,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ExemptHandlerWithContext(ctx
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "ExemptHandler")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "ExemptHandler")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -1028,12 +1030,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ExemptHandlerWithContext(ctx
 
 // ListAccountExemptions : List all exemptions
 // List all of the exemptions in the given account.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListAccountExemptions(listAccountExemptionsOptions *ListAccountExemptionsOptions) (result []Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ListAccountExemptions(listAccountExemptionsOptions *ListAccountExemptionsOptions) (result []Exemption, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.ListAccountExemptionsWithContext(context.Background(), listAccountExemptionsOptions)
 }
 
 // ListAccountExemptionsWithContext is an alternate form of the ListAccountExemptions method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListAccountExemptionsWithContext(ctx context.Context, listAccountExemptionsOptions *ListAccountExemptionsOptions) (result []Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ListAccountExemptionsWithContext(ctx context.Context, listAccountExemptionsOptions *ListAccountExemptionsOptions) (result []Exemption, response *core.DetailedResponse, err error) {
 	err = core.ValidateStruct(listAccountExemptionsOptions, "listAccountExemptionsOptions")
 	if err != nil {
 		return
@@ -1042,7 +1044,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListAccountExemptionsWithCon
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exemptions/account`, nil)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exemptions/account`, nil)
 	if err != nil {
 		return
 	}
@@ -1051,7 +1053,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListAccountExemptionsWithCon
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "ListAccountExemptions")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "ListAccountExemptions")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -1086,12 +1088,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListAccountExemptionsWithCon
 
 // ExemptionsAccountDeleteHandler : Delete all exemptions
 // Delete all of the exemptions in the given account.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ExemptionsAccountDeleteHandler(exemptionsAccountDeleteHandlerOptions *ExemptionsAccountDeleteHandlerOptions) (result *ExemptionDeletionInfo, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ExemptionsAccountDeleteHandler(exemptionsAccountDeleteHandlerOptions *ExemptionsAccountDeleteHandlerOptions) (result *ExemptionDeletionInfo, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.ExemptionsAccountDeleteHandlerWithContext(context.Background(), exemptionsAccountDeleteHandlerOptions)
 }
 
 // ExemptionsAccountDeleteHandlerWithContext is an alternate form of the ExemptionsAccountDeleteHandler method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ExemptionsAccountDeleteHandlerWithContext(ctx context.Context, exemptionsAccountDeleteHandlerOptions *ExemptionsAccountDeleteHandlerOptions) (result *ExemptionDeletionInfo, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ExemptionsAccountDeleteHandlerWithContext(ctx context.Context, exemptionsAccountDeleteHandlerOptions *ExemptionsAccountDeleteHandlerOptions) (result *ExemptionDeletionInfo, response *core.DetailedResponse, err error) {
 	err = core.ValidateStruct(exemptionsAccountDeleteHandlerOptions, "exemptionsAccountDeleteHandlerOptions")
 	if err != nil {
 		return
@@ -1100,7 +1102,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ExemptionsAccountDeleteHandl
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exemptions/deleteAll`, nil)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exemptions/deleteAll`, nil)
 	if err != nil {
 		return
 	}
@@ -1109,7 +1111,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ExemptionsAccountDeleteHandl
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "ExemptionsAccountDeleteHandler")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "ExemptionsAccountDeleteHandler")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -1144,12 +1146,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ExemptionsAccountDeleteHandl
 
 // ListImageExemptions : List image exemptions
 // List all of the exemptions for an image.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListImageExemptions(listImageExemptionsOptions *ListImageExemptionsOptions) (result []Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ListImageExemptions(listImageExemptionsOptions *ListImageExemptionsOptions) (result []Exemption, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.ListImageExemptionsWithContext(context.Background(), listImageExemptionsOptions)
 }
 
 // ListImageExemptionsWithContext is an alternate form of the ListImageExemptions method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListImageExemptionsWithContext(ctx context.Context, listImageExemptionsOptions *ListImageExemptionsOptions) (result []Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ListImageExemptionsWithContext(ctx context.Context, listImageExemptionsOptions *ListImageExemptionsOptions) (result []Exemption, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(listImageExemptionsOptions, "listImageExemptionsOptions cannot be nil")
 	if err != nil {
 		return
@@ -1166,7 +1168,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListImageExemptionsWithConte
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exemptions/image/{resource}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exemptions/image/{resource}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1175,7 +1177,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListImageExemptionsWithConte
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "ListImageExemptions")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "ListImageExemptions")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -1214,12 +1216,12 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListImageExemptionsWithConte
 
 // ListBulkImageExemptions : List exemptions for images
 // List the exemptions for the given list of images.
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListBulkImageExemptions(listBulkImageExemptionsOptions *ListBulkImageExemptionsOptions) (result map[string][]Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ListBulkImageExemptions(listBulkImageExemptionsOptions *ListBulkImageExemptionsOptions) (result map[string][]Exemption, response *core.DetailedResponse, err error) {
 	return vulnerabilityAdvisor.ListBulkImageExemptionsWithContext(context.Background(), listBulkImageExemptionsOptions)
 }
 
 // ListBulkImageExemptionsWithContext is an alternate form of the ListBulkImageExemptions method which supports a Context parameter
-func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListBulkImageExemptionsWithContext(ctx context.Context, listBulkImageExemptionsOptions *ListBulkImageExemptionsOptions) (result map[string][]Exemption, response *core.DetailedResponse, err error) {
+func (vulnerabilityAdvisor *VulnerabilityAdvisorV4) ListBulkImageExemptionsWithContext(ctx context.Context, listBulkImageExemptionsOptions *ListBulkImageExemptionsOptions) (result map[string][]Exemption, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(listBulkImageExemptionsOptions, "listBulkImageExemptionsOptions cannot be nil")
 	if err != nil {
 		return
@@ -1232,7 +1234,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListBulkImageExemptionsWithC
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = vulnerabilityAdvisor.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v3/exemptions/images`, nil)
+	_, err = builder.ResolveRequestURL(vulnerabilityAdvisor.Service.Options.URL, `/va/api/v4/exemptions/images`, nil)
 	if err != nil {
 		return
 	}
@@ -1241,7 +1243,7 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListBulkImageExemptionsWithC
 		builder.AddHeader(headerName, headerValue)
 	}
 
-	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V3", "ListBulkImageExemptions")
+	sdkHeaders := common.GetSdkHeaders("vulnerability_advisor", "V4", "ListBulkImageExemptions")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -1284,22 +1286,22 @@ func (vulnerabilityAdvisor *VulnerabilityAdvisorV3) ListBulkImageExemptionsWithC
 type AccountReportQueryPathOptions struct {
 	// The name of the repository that you want to see image vulnerability assessments for. For example,
 	// us.icr.io/namespace/image.
-	Repository *string `json:"-"`
+	Repository *string `json:"repository,omitempty"`
 
 	// When set to true, the returned list contains IBM public images and the account images. If not set, or set to false,
 	// the list contains only the account images.
-	IncludeIBM *string `json:"-"`
+	IncludeIBM *string `json:"includeIBM,omitempty"`
 
 	// When set to false, the returned list does not contain the private account images. If not set, or set to true, the
 	// list contains the private account images.
-	IncludePrivate *string `json:"-"`
+	IncludePrivate *string `json:"includePrivate,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewAccountReportQueryPathOptions : Instantiate AccountReportQueryPathOptions
-func (*VulnerabilityAdvisorV3) NewAccountReportQueryPathOptions() *AccountReportQueryPathOptions {
+func (*VulnerabilityAdvisorV4) NewAccountReportQueryPathOptions() *AccountReportQueryPathOptions {
 	return &AccountReportQueryPathOptions{}
 }
 
@@ -1331,22 +1333,22 @@ func (options *AccountReportQueryPathOptions) SetHeaders(param map[string]string
 type AccountStatusQueryPathOptions struct {
 	// The name of the repository that you want to see image vulnerability assessments for. For example,
 	// us.icr.io/namespace/image.
-	Repository *string `json:"-"`
+	Repository *string `json:"repository,omitempty"`
 
 	// When set to true, the returned list contains IBM public images and the account images. If not set, or set to false,
 	// the list contains only the account images.
-	IncludeIBM *string `json:"-"`
+	IncludeIBM *string `json:"includeIBM,omitempty"`
 
 	// When set to false, the returned list does not contain the private account images. If not set, or set to true, the
 	// list contains the private account images.
-	IncludePrivate *string `json:"-"`
+	IncludePrivate *string `json:"includePrivate,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewAccountStatusQueryPathOptions : Instantiate AccountStatusQueryPathOptions
-func (*VulnerabilityAdvisorV3) NewAccountStatusQueryPathOptions() *AccountStatusQueryPathOptions {
+func (*VulnerabilityAdvisorV4) NewAccountStatusQueryPathOptions() *AccountStatusQueryPathOptions {
 	return &AccountStatusQueryPathOptions{}
 }
 
@@ -1376,21 +1378,21 @@ func (options *AccountStatusQueryPathOptions) SetHeaders(param map[string]string
 
 // CreateExemptionAccountOptions : The CreateExemptionAccount options.
 type CreateExemptionAccountOptions struct {
-	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v3/exempt/types for more details.
-	IssueType *string `json:"-" validate:"required,ne="`
+	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v4/exempt/types for more details.
+	IssueType *string `json:"issueType" validate:"required,ne="`
 
-	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v3/exempt/types for more details.
-	IssueID *string `json:"-" validate:"required,ne="`
+	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v4/exempt/types for more details.
+	IssueID *string `json:"issueID" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewCreateExemptionAccountOptions : Instantiate CreateExemptionAccountOptions
-func (*VulnerabilityAdvisorV3) NewCreateExemptionAccountOptions(issueType string, issueID string) *CreateExemptionAccountOptions {
+func (*VulnerabilityAdvisorV4) NewCreateExemptionAccountOptions(issueType string, issueID string) *CreateExemptionAccountOptions {
 	return &CreateExemptionAccountOptions{
 		IssueType: core.StringPtr(issueType),
-		IssueID:   core.StringPtr(issueID),
+		IssueID: core.StringPtr(issueID),
 	}
 }
 
@@ -1416,24 +1418,24 @@ func (options *CreateExemptionAccountOptions) SetHeaders(param map[string]string
 type CreateExemptionResourceOptions struct {
 	// IBM Cloud Registry resource (namespace, namespace/repository, namespace/repository:tag, or
 	// namespace/repository@sha256:hash).
-	Resource *string `json:"-" validate:"required,ne="`
+	Resource *string `json:"resource" validate:"required,ne="`
 
-	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v3/exempt/types for more details.
-	IssueType *string `json:"-" validate:"required,ne="`
+	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v4/exempt/types for more details.
+	IssueType *string `json:"issueType" validate:"required,ne="`
 
-	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v3/exempt/types for more details.
-	IssueID *string `json:"-" validate:"required,ne="`
+	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v4/exempt/types for more details.
+	IssueID *string `json:"issueID" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewCreateExemptionResourceOptions : Instantiate CreateExemptionResourceOptions
-func (*VulnerabilityAdvisorV3) NewCreateExemptionResourceOptions(resource string, issueType string, issueID string) *CreateExemptionResourceOptions {
+func (*VulnerabilityAdvisorV4) NewCreateExemptionResourceOptions(resource string, issueType string, issueID string) *CreateExemptionResourceOptions {
 	return &CreateExemptionResourceOptions{
-		Resource:  core.StringPtr(resource),
+		Resource: core.StringPtr(resource),
 		IssueType: core.StringPtr(issueType),
-		IssueID:   core.StringPtr(issueID),
+		IssueID: core.StringPtr(issueID),
 	}
 }
 
@@ -1463,21 +1465,21 @@ func (options *CreateExemptionResourceOptions) SetHeaders(param map[string]strin
 
 // DeleteExemptionAccountOptions : The DeleteExemptionAccount options.
 type DeleteExemptionAccountOptions struct {
-	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v3/exempt/types for more details.
-	IssueType *string `json:"-" validate:"required,ne="`
+	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v4/exempt/types for more details.
+	IssueType *string `json:"issueType" validate:"required,ne="`
 
-	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v3/exempt/types for more details.
-	IssueID *string `json:"-" validate:"required,ne="`
+	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v4/exempt/types for more details.
+	IssueID *string `json:"issueID" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewDeleteExemptionAccountOptions : Instantiate DeleteExemptionAccountOptions
-func (*VulnerabilityAdvisorV3) NewDeleteExemptionAccountOptions(issueType string, issueID string) *DeleteExemptionAccountOptions {
+func (*VulnerabilityAdvisorV4) NewDeleteExemptionAccountOptions(issueType string, issueID string) *DeleteExemptionAccountOptions {
 	return &DeleteExemptionAccountOptions{
 		IssueType: core.StringPtr(issueType),
-		IssueID:   core.StringPtr(issueID),
+		IssueID: core.StringPtr(issueID),
 	}
 }
 
@@ -1503,24 +1505,24 @@ func (options *DeleteExemptionAccountOptions) SetHeaders(param map[string]string
 type DeleteExemptionResourceOptions struct {
 	// IBM Cloud Registry resource (namespace, namespace/repository, namespace/repository:tag, or
 	// namespace/repository@sha256:hash).
-	Resource *string `json:"-" validate:"required,ne="`
+	Resource *string `json:"resource" validate:"required,ne="`
 
-	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v3/exempt/types for more details.
-	IssueType *string `json:"-" validate:"required,ne="`
+	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v4/exempt/types for more details.
+	IssueType *string `json:"issueType" validate:"required,ne="`
 
-	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v3/exempt/types for more details.
-	IssueID *string `json:"-" validate:"required,ne="`
+	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v4/exempt/types for more details.
+	IssueID *string `json:"issueID" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewDeleteExemptionResourceOptions : Instantiate DeleteExemptionResourceOptions
-func (*VulnerabilityAdvisorV3) NewDeleteExemptionResourceOptions(resource string, issueType string, issueID string) *DeleteExemptionResourceOptions {
+func (*VulnerabilityAdvisorV4) NewDeleteExemptionResourceOptions(resource string, issueType string, issueID string) *DeleteExemptionResourceOptions {
 	return &DeleteExemptionResourceOptions{
-		Resource:  core.StringPtr(resource),
+		Resource: core.StringPtr(resource),
 		IssueType: core.StringPtr(issueType),
-		IssueID:   core.StringPtr(issueID),
+		IssueID: core.StringPtr(issueID),
 	}
 }
 
@@ -1556,7 +1558,7 @@ type ExemptHandlerOptions struct {
 }
 
 // NewExemptHandlerOptions : Instantiate ExemptHandlerOptions
-func (*VulnerabilityAdvisorV3) NewExemptHandlerOptions() *ExemptHandlerOptions {
+func (*VulnerabilityAdvisorV4) NewExemptHandlerOptions() *ExemptHandlerOptions {
 	return &ExemptHandlerOptions{}
 }
 
@@ -1649,7 +1651,7 @@ type ExemptionsAccountDeleteHandlerOptions struct {
 }
 
 // NewExemptionsAccountDeleteHandlerOptions : Instantiate ExemptionsAccountDeleteHandlerOptions
-func (*VulnerabilityAdvisorV3) NewExemptionsAccountDeleteHandlerOptions() *ExemptionsAccountDeleteHandlerOptions {
+func (*VulnerabilityAdvisorV4) NewExemptionsAccountDeleteHandlerOptions() *ExemptionsAccountDeleteHandlerOptions {
 	return &ExemptionsAccountDeleteHandlerOptions{}
 }
 
@@ -1661,21 +1663,21 @@ func (options *ExemptionsAccountDeleteHandlerOptions) SetHeaders(param map[strin
 
 // GetExemptionAccountOptions : The GetExemptionAccount options.
 type GetExemptionAccountOptions struct {
-	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v3/exempt/types for more details.
-	IssueType *string `json:"-" validate:"required,ne="`
+	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v4/exempt/types for more details.
+	IssueType *string `json:"issueType" validate:"required,ne="`
 
-	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v3/exempt/types for more details.
-	IssueID *string `json:"-" validate:"required,ne="`
+	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v4/exempt/types for more details.
+	IssueID *string `json:"issueID" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewGetExemptionAccountOptions : Instantiate GetExemptionAccountOptions
-func (*VulnerabilityAdvisorV3) NewGetExemptionAccountOptions(issueType string, issueID string) *GetExemptionAccountOptions {
+func (*VulnerabilityAdvisorV4) NewGetExemptionAccountOptions(issueType string, issueID string) *GetExemptionAccountOptions {
 	return &GetExemptionAccountOptions{
 		IssueType: core.StringPtr(issueType),
-		IssueID:   core.StringPtr(issueID),
+		IssueID: core.StringPtr(issueID),
 	}
 }
 
@@ -1701,24 +1703,24 @@ func (options *GetExemptionAccountOptions) SetHeaders(param map[string]string) *
 type GetExemptionResourceOptions struct {
 	// IBM Cloud Registry resource (namespace, namespace/repository, namespace/repository:tag, or
 	// namespace/repository@sha256:hash).
-	Resource *string `json:"-" validate:"required,ne="`
+	Resource *string `json:"resource" validate:"required,ne="`
 
-	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v3/exempt/types for more details.
-	IssueType *string `json:"-" validate:"required,ne="`
+	// Exemption type, e.g. 'cve' or 'sn' or 'configuration'. See /va/api/v4/exempt/types for more details.
+	IssueType *string `json:"issueType" validate:"required,ne="`
 
-	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v3/exempt/types for more details.
-	IssueID *string `json:"-" validate:"required,ne="`
+	// Exemption ID, e.g. 'CVE-2018-9999'. See /va/api/v4/exempt/types for more details.
+	IssueID *string `json:"issueID" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewGetExemptionResourceOptions : Instantiate GetExemptionResourceOptions
-func (*VulnerabilityAdvisorV3) NewGetExemptionResourceOptions(resource string, issueType string, issueID string) *GetExemptionResourceOptions {
+func (*VulnerabilityAdvisorV4) NewGetExemptionResourceOptions(resource string, issueType string, issueID string) *GetExemptionResourceOptions {
 	return &GetExemptionResourceOptions{
-		Resource:  core.StringPtr(resource),
+		Resource: core.StringPtr(resource),
 		IssueType: core.StringPtr(issueType),
-		IssueID:   core.StringPtr(issueID),
+		IssueID: core.StringPtr(issueID),
 	}
 }
 
@@ -1749,14 +1751,14 @@ func (options *GetExemptionResourceOptions) SetHeaders(param map[string]string) 
 // ImageReportQueryPathOptions : The ImageReportQueryPath options.
 type ImageReportQueryPathOptions struct {
 	// The name of the image. For example, us.icr.io/namespace/repository:tag.
-	Name *string `json:"-" validate:"required,ne="`
+	Name *string `json:"name" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewImageReportQueryPathOptions : Instantiate ImageReportQueryPathOptions
-func (*VulnerabilityAdvisorV3) NewImageReportQueryPathOptions(name string) *ImageReportQueryPathOptions {
+func (*VulnerabilityAdvisorV4) NewImageReportQueryPathOptions(name string) *ImageReportQueryPathOptions {
 	return &ImageReportQueryPathOptions{
 		Name: core.StringPtr(name),
 	}
@@ -1777,14 +1779,14 @@ func (options *ImageReportQueryPathOptions) SetHeaders(param map[string]string) 
 // ImageStatusQueryPathOptions : The ImageStatusQueryPath options.
 type ImageStatusQueryPathOptions struct {
 	// The name of the image. For example, us.icr.io/namespace/repository:tag.
-	Name *string `json:"-" validate:"required,ne="`
+	Name *string `json:"name" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewImageStatusQueryPathOptions : Instantiate ImageStatusQueryPathOptions
-func (*VulnerabilityAdvisorV3) NewImageStatusQueryPathOptions(name string) *ImageStatusQueryPathOptions {
+func (*VulnerabilityAdvisorV4) NewImageStatusQueryPathOptions(name string) *ImageStatusQueryPathOptions {
 	return &ImageStatusQueryPathOptions{
 		Name: core.StringPtr(name),
 	}
@@ -1810,7 +1812,7 @@ type ListAccountExemptionsOptions struct {
 }
 
 // NewListAccountExemptionsOptions : Instantiate ListAccountExemptionsOptions
-func (*VulnerabilityAdvisorV3) NewListAccountExemptionsOptions() *ListAccountExemptionsOptions {
+func (*VulnerabilityAdvisorV4) NewListAccountExemptionsOptions() *ListAccountExemptionsOptions {
 	return &ListAccountExemptionsOptions{}
 }
 
@@ -1830,7 +1832,7 @@ type ListBulkImageExemptionsOptions struct {
 }
 
 // NewListBulkImageExemptionsOptions : Instantiate ListBulkImageExemptionsOptions
-func (*VulnerabilityAdvisorV3) NewListBulkImageExemptionsOptions(body []string) *ListBulkImageExemptionsOptions {
+func (*VulnerabilityAdvisorV4) NewListBulkImageExemptionsOptions(body []string) *ListBulkImageExemptionsOptions {
 	return &ListBulkImageExemptionsOptions{
 		Body: body,
 	}
@@ -1856,7 +1858,7 @@ type ListExemptionAccountOptions struct {
 }
 
 // NewListExemptionAccountOptions : Instantiate ListExemptionAccountOptions
-func (*VulnerabilityAdvisorV3) NewListExemptionAccountOptions() *ListExemptionAccountOptions {
+func (*VulnerabilityAdvisorV4) NewListExemptionAccountOptions() *ListExemptionAccountOptions {
 	return &ListExemptionAccountOptions{}
 }
 
@@ -1870,14 +1872,14 @@ func (options *ListExemptionAccountOptions) SetHeaders(param map[string]string) 
 type ListExemptionResourceOptions struct {
 	// IBM Cloud Registry resource (namespace, namespace/repository, namespace/repository:tag, or
 	// namespace/repository@sha256:hash).
-	Resource *string `json:"-" validate:"required,ne="`
+	Resource *string `json:"resource" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewListExemptionResourceOptions : Instantiate ListExemptionResourceOptions
-func (*VulnerabilityAdvisorV3) NewListExemptionResourceOptions(resource string) *ListExemptionResourceOptions {
+func (*VulnerabilityAdvisorV4) NewListExemptionResourceOptions(resource string) *ListExemptionResourceOptions {
 	return &ListExemptionResourceOptions{
 		Resource: core.StringPtr(resource),
 	}
@@ -1899,17 +1901,17 @@ func (options *ListExemptionResourceOptions) SetHeaders(param map[string]string)
 type ListImageExemptionsOptions struct {
 	// IBM Cloud Registry resource (namespace, namespace/repository, namespace/repository:tag, or
 	// namespace/repository@sha256:hash).
-	Resource *string `json:"-" validate:"required,ne="`
+	Resource *string `json:"resource" validate:"required,ne="`
 
 	// Include scope on returned exemptions.
-	IncludeScope *bool `json:"-"`
+	IncludeScope *bool `json:"includeScope,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // NewListImageExemptionsOptions : Instantiate ListImageExemptionsOptions
-func (*VulnerabilityAdvisorV3) NewListImageExemptionsOptions(resource string) *ListImageExemptionsOptions {
+func (*VulnerabilityAdvisorV4) NewListImageExemptionsOptions(resource string) *ListImageExemptionsOptions {
 	return &ListImageExemptionsOptions{
 		Resource: core.StringPtr(resource),
 	}
@@ -1935,13 +1937,16 @@ func (options *ListImageExemptionsOptions) SetHeaders(param map[string]string) *
 
 // ScanReport : ScanReport struct
 type ScanReport struct {
-	// Possible configuration issues found in the docker object.
+	// Not supported, will always be empty.
 	ConfigurationIssues []ScanresultConfigurationIssue `json:"configuration_issues" validate:"required"`
 
 	// The unique ID of the report.
 	ID *string `json:"id" validate:"required"`
 
-	// The scan time of the report as a UNIX timestamp.
+	// The primary operating system distribution identified in the container image.
+	OsDistribution *ScanReportOsDistribution `json:"os_distribution" validate:"required"`
+
+	// The last time that the vulnerability data source was checked for vulnerabilities as a UNIX timestamp.
 	ScanTime *int64 `json:"scan_time" validate:"required"`
 
 	// Overall vulnerability assessment status: OK, WARN, FAIL, UNSUPPORTED, INCOMPLETE, UNSCANNED. For more information
@@ -1949,7 +1954,7 @@ type ScanReport struct {
 	// https://{DomainName}/apidocs/container-registry/va#getting-started-vulnerability-report-status-codes.
 	Status *string `json:"status" validate:"required"`
 
-	// Vulnerabilities found in the docker object at the scan time.
+	// Vulnerabilities found in the container image at the scan time.
 	Vulnerabilities []ScanresultCVE `json:"vulnerabilities" validate:"required"`
 }
 
@@ -1961,6 +1966,10 @@ func UnmarshalScanReport(m map[string]json.RawMessage, result interface{}) (err 
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "os_distribution", &obj.OsDistribution, UnmarshalScanReportOsDistribution)
 	if err != nil {
 		return
 	}
@@ -1990,6 +1999,37 @@ type ScanReportList struct {
 func UnmarshalScanReportList(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(ScanReportList)
 	err = core.UnmarshalModel(m, "assessments", &obj.Assessments, UnmarshalScanReport)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// ScanReportOsDistribution : The primary operating system distribution identified in the container image.
+type ScanReportOsDistribution struct {
+	// Primary operating system distribution.
+	DistributionID *string `json:"distribution_id,omitempty"`
+
+	// Primary operating system version.
+	VersionID *string `json:"version_id,omitempty"`
+
+	// Primary operating system version code name.
+	VersionCodeName *string `json:"version_code_name,omitempty"`
+}
+
+// UnmarshalScanReportOsDistribution unmarshals an instance of ScanReportOsDistribution from the specified map of raw messages.
+func UnmarshalScanReportOsDistribution(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(ScanReportOsDistribution)
+	err = core.UnmarshalPrimitive(m, "distribution_id", &obj.DistributionID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "version_id", &obj.VersionID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "version_code_name", &obj.VersionCodeName)
 	if err != nil {
 		return
 	}
@@ -2049,13 +2089,13 @@ func UnmarshalExemptionTypeInfo(m map[string]json.RawMessage, result interface{}
 
 // ScanreportImageSummary : ScanreportImageSummary struct
 type ScanreportImageSummary struct {
-	// The number of configuration issues found.
+	// Not supported, this will always be zero.
 	ConfigurationIssueCount *int64 `json:"configuration_issue_count" validate:"required"`
 
 	// The image creation time as a UNIX timestamp.
 	CreatedTime *int64 `json:"created_time" validate:"required"`
 
-	// The number of exempt configuration issues found.
+	// Not supported, this will always be zero.
 	ExemptConfigurationIssueCount *int64 `json:"exempt_configuration_issue_count" validate:"required"`
 
 	// The number of exempt issues found.
@@ -2070,7 +2110,7 @@ type ScanreportImageSummary struct {
 	// Full docker image name including tag e.g. us.icr.io/namespace/repository:tag.
 	Name *string `json:"name" validate:"required"`
 
-	// The scan time of the report as a UNIX timestamp.
+	// The last time that the vulnerability data source was checked for vulnerabilities as a UNIX timestamp.
 	ScanTime *int64 `json:"scan_time" validate:"required"`
 
 	// Overall vulnerability assessment status: OK, WARN, FAIL, UNSUPPORTED, INCOMPLETE, UNSCANNED. For more information
@@ -2148,10 +2188,10 @@ func UnmarshalScanreportImageSummaryList(m map[string]json.RawMessage, result in
 
 // ScanreportSummary : ScanreportSummary struct
 type ScanreportSummary struct {
-	// The number of configuration issues found.
+	// Not supported, this will always be zero.
 	ConfigurationIssueCount *int64 `json:"configuration_issue_count" validate:"required"`
 
-	// The number of exempt configuration issues found.
+	// Not supported, this will always be zero.
 	ExemptConfigurationIssueCount *int64 `json:"exempt_configuration_issue_count" validate:"required"`
 
 	// The number of exempt issues found.
@@ -2163,7 +2203,7 @@ type ScanreportSummary struct {
 	// The number of issues found.
 	IssueCount *int64 `json:"issue_count" validate:"required"`
 
-	// The scan time of the report as a UNIX timestamp.
+	// The last time that the vulnerability data source was checked for vulnerabilities as a UNIX timestamp.
 	ScanTime *int64 `json:"scan_time" validate:"required"`
 
 	// Overall vulnerability assessment status: OK, WARN, FAIL, UNSUPPORTED, INCOMPLETE, UNSCANNED. For more information
@@ -2284,19 +2324,19 @@ func UnmarshalScanresultCVE(m map[string]json.RawMessage, result interface{}) (e
 
 // ScanresultConfigurationIssue : ScanresultConfigurationIssue struct
 type ScanresultConfigurationIssue struct {
-	// Advice on how to solve this ConfigurationIssue.
+	// Not supported.
 	CorrectiveAction *string `json:"corrective_action" validate:"required"`
 
-	// Description of this ConfigurationIssue.
+	// Not supported.
 	Description *string `json:"description" validate:"required"`
 
-	// True if this configuration issue is exempted by user policy, and false otherwise.
+	// Not supported.
 	Exempt *bool `json:"exempt" validate:"required"`
 
-	// Additional keys and string values about this ConfigurationIssue.
+	// Not supported.
 	Meta map[string]string `json:"meta" validate:"required"`
 
-	// The ID of the check which found this ConfigurationIssue.
+	// Not supported.
 	Type *string `json:"type" validate:"required"`
 }
 

--- a/vulnerabilityadvisorv4/vulnerability_advisor_v4_examples_test.go
+++ b/vulnerabilityadvisorv4/vulnerability_advisor_v4_examples_test.go
@@ -1,7 +1,8 @@
+//go:build examples
 // +build examples
 
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,56 +17,70 @@
  * limitations under the License.
  */
 
-package vulnerabilityadvisorv3_test
+package vulnerabilityadvisorv4_test
 
 import (
 	"encoding/json"
 	"fmt"
 	"os"
 
-	"github.com/IBM/container-registry-go-sdk/vulnerabilityadvisorv3"
+	"github.com/IBM/container-registry-go-sdk/vulnerabilityadvisorv4"
 	"github.com/IBM/go-sdk-core/v5/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-const externalConfigFile = "../vulnerability_advisor_v3.env"
-
-var (
-	vulnerabilityAdvisorService *vulnerabilityadvisorv3.VulnerabilityAdvisorV3
-	config                      map[string]string
-	configLoaded                bool = false
-)
+//
+// This file provides an example of how to use the Vulnerability Advisor service.
+//
+// The following configuration properties are assumed to be defined:
+// VULNERABILITY_ADVISOR_URL=<service base url>
+// VULNERABILITY_ADVISOR_AUTH_TYPE=iam
+// VULNERABILITY_ADVISOR_APIKEY=<IAM apikey>
+// VULNERABILITY_ADVISOR_AUTH_URL=<IAM token service base URL - omit this if using the production environment>
+//
+// These configuration properties can be exported as environment variables, or stored
+// in a configuration file and then:
+// export IBM_CREDENTIALS_FILE=<name of configuration file>
+//
 
 func shouldSkipTest() {
 	Skip("Container Registry examples are not intended to be runnable tests")
-	if !configLoaded {
-		Skip("External configuration is not available, skipping tests...")
-	}
 }
 
-var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
+var _ = Describe(`VulnerabilityAdvisorV4 Examples Tests`, func() {
+
+	const externalConfigFile = "../vulnerability_advisor_v4.env"
+
+	var (
+		vulnerabilityAdvisorService *vulnerabilityadvisorv4.VulnerabilityAdvisorV4
+		config                      map[string]string
+	)
+
+	var shouldSkipTest = func() {
+		Skip("External configuration is not available, skipping examples...")
+	}
+
 	Describe(`External configuration`, func() {
 		It("Successfully load the configuration", func() {
 			var err error
 			_, err = os.Stat(externalConfigFile)
 			if err != nil {
-				Skip("External configuration file not found, skipping tests: " + err.Error())
-			}
-			/**
-			Your configuration file (vulnerability_advisor_v3.env) should contain the following variables.
-			VULNERABILITY_ADVISOR_URL=[Registry URL, eg https://uk.icr.io]
-			VULNERABILITY_ADVISOR_AUTH_TYPE=iam
-			VULNERABILITY_ADVISOR_AUTH_URL=https://iam.cloud.ibm.com/identity/token
-			VULNERABILITY_ADVISOR_APIKEY=[An IAM Apikey]
-			*/
-			os.Setenv("IBM_CREDENTIALS_FILE", externalConfigFile)
-			config, err = core.GetServiceProperties(vulnerabilityadvisorv3.DefaultServiceName)
-			if err != nil {
-				Skip("Error loading service properties, skipping tests: " + err.Error())
+				Skip("External configuration file not found, skipping examples: " + err.Error())
 			}
 
-			configLoaded = len(config) > 0
+			os.Setenv("IBM_CREDENTIALS_FILE", externalConfigFile)
+			config, err = core.GetServiceProperties(vulnerabilityadvisorv4.DefaultServiceName)
+			if err != nil {
+				Skip("Error loading service properties, skipping examples: " + err.Error())
+			} else if len(config) == 0 {
+				Skip("Unable to load service properties, skipping examples")
+			}
+
+			// we have config but we dont want these tests to run anyway
+			shouldSkipTest = func() {
+				Skip("Container Registry examples are not intended to be runnable")
+			}
 		})
 	})
 
@@ -78,11 +93,11 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 
 			// begin-common
 
-			vulnerabilityAdvisorServiceOptions := &vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
+			vulnerabilityAdvisorServiceOptions := &vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
 				Account: core.StringPtr("accountID"),
 			}
 
-			vulnerabilityAdvisorService, err = vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3UsingExternalConfig(vulnerabilityAdvisorServiceOptions)
+			vulnerabilityAdvisorService, err = vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4UsingExternalConfig(vulnerabilityAdvisorServiceOptions)
 
 			if err != nil {
 				panic(err)
@@ -94,11 +109,12 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 		})
 	})
 
-	Describe(`VulnerabilityAdvisorV3 request examples`, func() {
+	Describe(`VulnerabilityAdvisorV4 request examples`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
 		It(`AccountReportQueryPath request example`, func() {
+			fmt.Println("\nAccountReportQueryPath() result:")
 			// begin-accountReportQueryPath
 
 			accountReportQueryPathOptions := vulnerabilityAdvisorService.NewAccountReportQueryPathOptions()
@@ -117,14 +133,12 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(scanReportList).ToNot(BeNil())
-
 		})
 		It(`AccountStatusQueryPath request example`, func() {
+			fmt.Println("\nAccountStatusQueryPath() result:")
 			// begin-accountStatusQueryPath
 
 			accountStatusQueryPathOptions := vulnerabilityAdvisorService.NewAccountStatusQueryPathOptions()
-
-			accountStatusQueryPathOptions.IncludePrivate = core.StringPtr("true")
 
 			scanreportImageSummaryList, response, err := vulnerabilityAdvisorService.AccountStatusQueryPath(accountStatusQueryPathOptions)
 			if err != nil {
@@ -138,9 +152,30 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(scanreportImageSummaryList).ToNot(BeNil())
+		})
+		It(`ImageReportQueryPath request example`, func() {
+			fmt.Println("\nImageReportQueryPath() result:")
+			// begin-imageReportQueryPath
 
+			imageReportQueryPathOptions := vulnerabilityAdvisorService.NewImageReportQueryPathOptions(
+				"image name",
+			)
+
+			scanReport, response, err := vulnerabilityAdvisorService.ImageReportQueryPath(imageReportQueryPathOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(scanReport, "", "  ")
+			fmt.Println(string(b))
+
+			// end-imageReportQueryPath
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(scanReport).ToNot(BeNil())
 		})
 		It(`ImageStatusQueryPath request example`, func() {
+			fmt.Println("\nImageStatusQueryPath() result:")
 			// begin-imageStatusQueryPath
 
 			imageStatusQueryPathOptions := vulnerabilityAdvisorService.NewImageStatusQueryPathOptions(
@@ -159,30 +194,9 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(scanreportSummary).ToNot(BeNil())
-
-		})
-		It(`ImageReportQueryPath request example`, func() {
-			// begin-imageReportQueryPath
-
-			imageReportQueryPathOptions := vulnerabilityAdvisorService.NewImageReportQueryPathOptions(
-				"image name",
-			)
-
-			scanReport, response, err := vulnerabilityAdvisorService.ImageReportQueryPath(imageReportQueryPathOptions)
-			if err != nil {
-				panic(err)
-			}
-			b, _ := json.MarshalIndent(scanReport, "", "  ")
-			fmt.Println(string(b))
-
-			// end-imageReportQueryPath
-
-			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(202))
-			Expect(scanReport).ToNot(BeNil())
-
 		})
 		It(`ListExemptionAccount request example`, func() {
+			fmt.Println("\nListExemptionAccount() result:")
 			// begin-listExemptionAccount
 
 			listExemptionAccountOptions := vulnerabilityAdvisorService.NewListExemptionAccountOptions()
@@ -199,9 +213,9 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 		It(`GetExemptionAccount request example`, func() {
+			fmt.Println("\nGetExemptionAccount() result:")
 			// begin-getExemptionAccount
 
 			getExemptionAccountOptions := vulnerabilityAdvisorService.NewGetExemptionAccountOptions(
@@ -221,9 +235,9 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 		It(`CreateExemptionAccount request example`, func() {
+			fmt.Println("\nCreateExemptionAccount() result:")
 			// begin-createExemptionAccount
 
 			createExemptionAccountOptions := vulnerabilityAdvisorService.NewCreateExemptionAccountOptions(
@@ -243,9 +257,9 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(201))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 		It(`ListExemptionResource request example`, func() {
+			fmt.Println("\nListExemptionResource() result:")
 			// begin-listExemptionResource
 
 			listExemptionResourceOptions := vulnerabilityAdvisorService.NewListExemptionResourceOptions(
@@ -264,9 +278,9 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 		It(`GetExemptionResource request example`, func() {
+			fmt.Println("\nGetExemptionResource() result:")
 			// begin-getExemptionResource
 
 			getExemptionResourceOptions := vulnerabilityAdvisorService.NewGetExemptionResourceOptions(
@@ -287,9 +301,9 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 		It(`CreateExemptionResource request example`, func() {
+			fmt.Println("\nCreateExemptionResource() result:")
 			// begin-createExemptionResource
 
 			createExemptionResourceOptions := vulnerabilityAdvisorService.NewCreateExemptionResourceOptions(
@@ -310,9 +324,9 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(201))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 		It(`ExemptHandler request example`, func() {
+			fmt.Println("\nExemptHandler() result:")
 			// begin-exemptHandler
 
 			exemptHandlerOptions := vulnerabilityAdvisorService.NewExemptHandlerOptions()
@@ -329,9 +343,9 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemptionTypeInfo).ToNot(BeNil())
-
 		})
 		It(`ListAccountExemptions request example`, func() {
+			fmt.Println("\nListAccountExemptions() result:")
 			// begin-listAccountExemptions
 
 			listAccountExemptionsOptions := vulnerabilityAdvisorService.NewListAccountExemptionsOptions()
@@ -348,9 +362,9 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 		It(`ExemptionsAccountDeleteHandler request example`, func() {
+			fmt.Println("\nExemptionsAccountDeleteHandler() result:")
 			// begin-exemptionsAccountDeleteHandler
 
 			exemptionsAccountDeleteHandlerOptions := vulnerabilityAdvisorService.NewExemptionsAccountDeleteHandlerOptions()
@@ -367,9 +381,9 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemptionDeletionInfo).ToNot(BeNil())
-
 		})
 		It(`ListImageExemptions request example`, func() {
+			fmt.Println("\nListImageExemptions() result:")
 			// begin-listImageExemptions
 
 			listImageExemptionsOptions := vulnerabilityAdvisorService.NewListImageExemptionsOptions(
@@ -388,13 +402,13 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 		It(`ListBulkImageExemptions request example`, func() {
+			fmt.Println("\nListBulkImageExemptions() result:")
 			// begin-listBulkImageExemptions
 
 			listBulkImageExemptionsOptions := vulnerabilityAdvisorService.NewListBulkImageExemptionsOptions(
-				[]string{"image name"},
+				[]string{"us.icr.io/birds/woodpecker:green", "us.icr.io/birds/grebe:crested"},
 			)
 
 			mapStringExemption, response, err := vulnerabilityAdvisorService.ListBulkImageExemptions(listBulkImageExemptionsOptions)
@@ -409,7 +423,6 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(mapStringExemption).ToNot(BeNil())
-
 		})
 		It(`DeleteExemptionResource request example`, func() {
 			// begin-deleteExemptionResource
@@ -424,12 +437,14 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			if err != nil {
 				panic(err)
 			}
+			if response.StatusCode != 200 {
+				fmt.Printf("\nUnexpected response status code received from DeleteExemptionResource(): %d\n", response.StatusCode)
+			}
 
 			// end-deleteExemptionResource
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-
 		})
 		It(`DeleteExemptionAccount request example`, func() {
 			// begin-deleteExemptionAccount
@@ -443,12 +458,14 @@ var _ = Describe(`VulnerabilityAdvisorV3 Examples Tests`, func() {
 			if err != nil {
 				panic(err)
 			}
+			if response.StatusCode != 200 {
+				fmt.Printf("\nUnexpected response status code received from DeleteExemptionAccount(): %d\n", response.StatusCode)
+			}
 
 			// end-deleteExemptionAccount
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-
 		})
 	})
 })

--- a/vulnerabilityadvisorv4/vulnerability_advisor_v4_integration_test.go
+++ b/vulnerabilityadvisorv4/vulnerability_advisor_v4_integration_test.go
@@ -1,7 +1,8 @@
+//go:build integration
 // +build integration
 
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +17,27 @@
  * limitations under the License.
  */
 
-package vulnerabilityadvisorv3_test
+package vulnerabilityadvisorv4_test
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
+	"time"
 
-	"github.com/IBM/container-registry-go-sdk/vulnerabilityadvisorv3"
+	"github.com/IBM/container-registry-go-sdk/vulnerabilityadvisorv4"
 	"github.com/IBM/go-sdk-core/v5/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 /**
- * This file contains an integration test for the vulnerabilityadvisorv3 package.
+ * This file contains an integration test for the vulnerabilityadvisorv4 package.
  *
  * Notes:
- *
-* Your configuration file (vulnerability_advisor_v3.env) should contain the following variables.
+ * Your configuration file (vulnerability_advisor_v4.env) should contain the following variables.
+
 VULNERABILITY_ADVISOR_URL=[Registry URL, eg https://uk.icr.io]
 VULNERABILITY_ADVISOR_AUTH_TYPE=iam
 VULNERABILITY_ADVISOR_AUTH_URL=https://iam.cloud.ibm.com/identity/token
@@ -42,17 +45,17 @@ VULNERABILITY_ADVISOR_APIKEY=[An IAM Apikey]
 VULNERABILITY_ADVISOR_ACCOUNT_ID=[Your test account ID]
 VULNERABILITY_ADVISOR_NAMESPACE=[Namespace name used by the tests]
 VULNERABILITY_ADVISOR_SEED_IMAGE=[An existing namespace/repo:tag for which to get VA scans etc.]
+
  *
  * The integration test will automatically skip tests if the required config file is not available.
 */
 
-var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
-
-	const externalConfigFile = "../vulnerability_advisor_v3.env"
+var _ = Describe(`VulnerabilityAdvisorV4 Integration Tests`, func() {
+	const externalConfigFile = "../vulnerability_advisor_v4.env"
 
 	var (
 		err                         error
-		vulnerabilityAdvisorService *vulnerabilityadvisorv3.VulnerabilityAdvisorV3
+		vulnerabilityAdvisorService *vulnerabilityadvisorv4.VulnerabilityAdvisorV4
 		serviceURL                  string
 		baseNamespace               string
 		accountID                   string
@@ -73,7 +76,7 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			}
 
 			os.Setenv("IBM_CREDENTIALS_FILE", externalConfigFile)
-			config, err = core.GetServiceProperties(vulnerabilityadvisorv3.DefaultServiceName)
+			config, err = core.GetServiceProperties(vulnerabilityadvisorv4.DefaultServiceName)
 			if err != nil {
 				Skip("Error loading service properties, skipping tests: " + err.Error())
 			}
@@ -95,7 +98,7 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 				Skip("Unable to load seedImage configuration property, skipping tests")
 			}
 
-			fmt.Printf("Service URL: %s\n", serviceURL)
+			fmt.Fprintf(GinkgoWriter, "Service URL: %v\n", serviceURL)
 			shouldSkipTest = func() {}
 		})
 	})
@@ -105,16 +108,17 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It("Successfully construct the service client instance", func() {
-
-			vulnerabilityAdvisorServiceOptions := &vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
+			vulnerabilityAdvisorServiceOptions := &vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
 				Account: core.StringPtr(accountID),
 			}
 
-			vulnerabilityAdvisorService, err = vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3UsingExternalConfig(vulnerabilityAdvisorServiceOptions)
-
+			vulnerabilityAdvisorService, err = vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4UsingExternalConfig(vulnerabilityAdvisorServiceOptions)
 			Expect(err).To(BeNil())
 			Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 			Expect(vulnerabilityAdvisorService.Service.Options.URL).To(Equal(serviceURL))
+
+			core.SetLogger(core.NewLogger(core.LevelDebug, log.New(GinkgoWriter, "", log.LstdFlags), log.New(GinkgoWriter, "", log.LstdFlags)))
+			vulnerabilityAdvisorService.EnableRetries(4, 30*time.Second)
 		})
 	})
 
@@ -123,17 +127,16 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`AccountReportQueryPath(accountReportQueryPathOptions *AccountReportQueryPathOptions)`, func() {
-
-			accountReportQueryPathOptions := &vulnerabilityadvisorv3.AccountReportQueryPathOptions{
+			accountReportQueryPathOptions := &vulnerabilityadvisorv4.AccountReportQueryPathOptions{
+				//Repository: core.StringPtr("testString"),
+				IncludeIBM:     core.StringPtr("false"),
 				IncludePrivate: core.StringPtr("true"),
 			}
 
 			scanReportList, response, err := vulnerabilityAdvisorService.AccountReportQueryPath(accountReportQueryPathOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(scanReportList).ToNot(BeNil())
-
 		})
 	})
 
@@ -142,17 +145,32 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`AccountStatusQueryPath(accountStatusQueryPathOptions *AccountStatusQueryPathOptions)`, func() {
-
-			accountStatusQueryPathOptions := &vulnerabilityadvisorv3.AccountStatusQueryPathOptions{
+			accountStatusQueryPathOptions := &vulnerabilityadvisorv4.AccountStatusQueryPathOptions{
+				//Repository:     core.StringPtr("testString"),
+				IncludeIBM:     core.StringPtr("false"),
 				IncludePrivate: core.StringPtr("true"),
 			}
 
 			scanreportImageSummaryList, response, err := vulnerabilityAdvisorService.AccountStatusQueryPath(accountStatusQueryPathOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(scanreportImageSummaryList).ToNot(BeNil())
+		})
+	})
 
+	Describe(`ImageReportQueryPath - Get vulnerability assessment`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`ImageReportQueryPath(imageReportQueryPathOptions *ImageReportQueryPathOptions)`, func() {
+			imageReportQueryPathOptions := &vulnerabilityadvisorv4.ImageReportQueryPathOptions{
+				Name: core.StringPtr(fmt.Sprintf("%s/%s", registryDNSName, seedImage)),
+			}
+
+			scanReport, response, err := vulnerabilityAdvisorService.ImageReportQueryPath(imageReportQueryPathOptions)
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(scanReport).ToNot(BeNil())
 		})
 	})
 
@@ -161,36 +179,14 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`ImageStatusQueryPath(imageStatusQueryPathOptions *ImageStatusQueryPathOptions)`, func() {
-
-			imageStatusQueryPathOptions := &vulnerabilityadvisorv3.ImageStatusQueryPathOptions{
+			imageStatusQueryPathOptions := &vulnerabilityadvisorv4.ImageStatusQueryPathOptions{
 				Name: core.StringPtr(fmt.Sprintf("%s/%s", registryDNSName, seedImage)),
 			}
 
 			scanreportSummary, response, err := vulnerabilityAdvisorService.ImageStatusQueryPath(imageStatusQueryPathOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(scanreportSummary).ToNot(BeNil())
-
-		})
-	})
-
-	Describe(`ImageReportQueryPath - Get vulnerability assessment status`, func() {
-		BeforeEach(func() {
-			shouldSkipTest()
-		})
-		It(`ImageReportQueryPath(imageReportQueryPathOptions *ImageReportQueryPathOptions)`, func() {
-
-			imageReportQueryPathOptions := &vulnerabilityadvisorv3.ImageReportQueryPathOptions{
-				Name: core.StringPtr(fmt.Sprintf("%s/%s", registryDNSName, seedImage)),
-			}
-
-			scanReport, response, err := vulnerabilityAdvisorService.ImageReportQueryPath(imageReportQueryPathOptions)
-
-			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(200))
-			Expect(scanReport).ToNot(BeNil())
-
 		})
 	})
 
@@ -199,18 +195,15 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`CreateExemptionAccount(createExemptionAccountOptions *CreateExemptionAccountOptions)`, func() {
-
-			createExemptionAccountOptions := &vulnerabilityadvisorv3.CreateExemptionAccountOptions{
+			createExemptionAccountOptions := &vulnerabilityadvisorv4.CreateExemptionAccountOptions{
 				IssueType: core.StringPtr("cve"),
 				IssueID:   core.StringPtr("CVE-2020-0001"),
 			}
 
 			exemption, response, err := vulnerabilityAdvisorService.CreateExemptionAccount(createExemptionAccountOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(201))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 	})
 
@@ -219,15 +212,12 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`ListExemptionAccount(listExemptionAccountOptions *ListExemptionAccountOptions)`, func() {
-
-			listExemptionAccountOptions := &vulnerabilityadvisorv3.ListExemptionAccountOptions{}
+			listExemptionAccountOptions := &vulnerabilityadvisorv4.ListExemptionAccountOptions{}
 
 			exemption, response, err := vulnerabilityAdvisorService.ListExemptionAccount(listExemptionAccountOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 	})
 
@@ -236,18 +226,15 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`GetExemptionAccount(getExemptionAccountOptions *GetExemptionAccountOptions)`, func() {
-
-			getExemptionAccountOptions := &vulnerabilityadvisorv3.GetExemptionAccountOptions{
+			getExemptionAccountOptions := &vulnerabilityadvisorv4.GetExemptionAccountOptions{
 				IssueType: core.StringPtr("cve"),
 				IssueID:   core.StringPtr("CVE-2020-0001"),
 			}
 
 			exemption, response, err := vulnerabilityAdvisorService.GetExemptionAccount(getExemptionAccountOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 	})
 
@@ -256,17 +243,14 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`DeleteExemptionAccount(deleteExemptionAccountOptions *DeleteExemptionAccountOptions)`, func() {
-
-			deleteExemptionAccountOptions := &vulnerabilityadvisorv3.DeleteExemptionAccountOptions{
+			deleteExemptionAccountOptions := &vulnerabilityadvisorv4.DeleteExemptionAccountOptions{
 				IssueType: core.StringPtr("cve"),
 				IssueID:   core.StringPtr("CVE-2020-0001"),
 			}
 
 			response, err := vulnerabilityAdvisorService.DeleteExemptionAccount(deleteExemptionAccountOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-
 		})
 	})
 
@@ -275,19 +259,16 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`CreateExemptionResource(createExemptionResourceOptions *CreateExemptionResourceOptions)`, func() {
-
-			createExemptionResourceOptions := &vulnerabilityadvisorv3.CreateExemptionResourceOptions{
+			createExemptionResourceOptions := &vulnerabilityadvisorv4.CreateExemptionResourceOptions{
 				IssueType: core.StringPtr("cve"),
 				IssueID:   core.StringPtr("CVE-2020-0001"),
 				Resource:  core.StringPtr(fmt.Sprintf("%s/%s", registryDNSName, seedImage)),
 			}
 
 			exemption, response, err := vulnerabilityAdvisorService.CreateExemptionResource(createExemptionResourceOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(201))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 	})
 
@@ -296,17 +277,14 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`ListExemptionResource(listExemptionResourceOptions *ListExemptionResourceOptions)`, func() {
-
-			listExemptionResourceOptions := &vulnerabilityadvisorv3.ListExemptionResourceOptions{
+			listExemptionResourceOptions := &vulnerabilityadvisorv4.ListExemptionResourceOptions{
 				Resource: core.StringPtr(fmt.Sprintf("%s/%s", registryDNSName, seedImage)),
 			}
 
 			exemption, response, err := vulnerabilityAdvisorService.ListExemptionResource(listExemptionResourceOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 	})
 
@@ -315,18 +293,15 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`ListImageExemptions(listImageExemptionsOptions *ListImageExemptionsOptions)`, func() {
-
-			listImageExemptionsOptions := &vulnerabilityadvisorv3.ListImageExemptionsOptions{
+			listImageExemptionsOptions := &vulnerabilityadvisorv4.ListImageExemptionsOptions{
 				Resource:     core.StringPtr(fmt.Sprintf("%s/%s", registryDNSName, seedImage)),
 				IncludeScope: core.BoolPtr(true),
 			}
 
 			exemption, response, err := vulnerabilityAdvisorService.ListImageExemptions(listImageExemptionsOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 	})
 
@@ -335,17 +310,14 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`ListBulkImageExemptions(listBulkImageExemptionsOptions *ListBulkImageExemptionsOptions)`, func() {
-
-			listBulkImageExemptionsOptions := &vulnerabilityadvisorv3.ListBulkImageExemptionsOptions{
+			listBulkImageExemptionsOptions := &vulnerabilityadvisorv4.ListBulkImageExemptionsOptions{
 				Body: []string{fmt.Sprintf("%s/%s", registryDNSName, seedImage)},
 			}
 
 			mapStringExemption, response, err := vulnerabilityAdvisorService.ListBulkImageExemptions(listBulkImageExemptionsOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(mapStringExemption).ToNot(BeNil())
-
 		})
 	})
 
@@ -354,15 +326,12 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`ListAccountExemptions(listAccountExemptionsOptions *ListAccountExemptionsOptions)`, func() {
-
-			listAccountExemptionsOptions := &vulnerabilityadvisorv3.ListAccountExemptionsOptions{}
+			listAccountExemptionsOptions := &vulnerabilityadvisorv4.ListAccountExemptionsOptions{}
 
 			exemption, response, err := vulnerabilityAdvisorService.ListAccountExemptions(listAccountExemptionsOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 	})
 
@@ -371,19 +340,16 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`GetExemptionResource(getExemptionResourceOptions *GetExemptionResourceOptions)`, func() {
-
-			getExemptionResourceOptions := &vulnerabilityadvisorv3.GetExemptionResourceOptions{
+			getExemptionResourceOptions := &vulnerabilityadvisorv4.GetExemptionResourceOptions{
 				IssueType: core.StringPtr("cve"),
 				IssueID:   core.StringPtr("CVE-2020-0001"),
 				Resource:  core.StringPtr(fmt.Sprintf("%s/%s", registryDNSName, seedImage)),
 			}
 
 			exemption, response, err := vulnerabilityAdvisorService.GetExemptionResource(getExemptionResourceOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemption).ToNot(BeNil())
-
 		})
 	})
 
@@ -392,18 +358,15 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`DeleteExemptionResource(deleteExemptionResourceOptions *DeleteExemptionResourceOptions)`, func() {
-
-			deleteExemptionResourceOptions := &vulnerabilityadvisorv3.DeleteExemptionResourceOptions{
+			deleteExemptionResourceOptions := &vulnerabilityadvisorv4.DeleteExemptionResourceOptions{
 				IssueType: core.StringPtr("cve"),
 				IssueID:   core.StringPtr("CVE-2020-0001"),
 				Resource:  core.StringPtr(fmt.Sprintf("%s/%s", registryDNSName, seedImage)),
 			}
 
 			response, err := vulnerabilityAdvisorService.DeleteExemptionResource(deleteExemptionResourceOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
-
 		})
 	})
 
@@ -412,15 +375,12 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`ExemptHandler(exemptHandlerOptions *ExemptHandlerOptions)`, func() {
-
-			exemptHandlerOptions := &vulnerabilityadvisorv3.ExemptHandlerOptions{}
+			exemptHandlerOptions := &vulnerabilityadvisorv4.ExemptHandlerOptions{}
 
 			exemptionTypeInfo, response, err := vulnerabilityAdvisorService.ExemptHandler(exemptHandlerOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemptionTypeInfo).ToNot(BeNil())
-
 		})
 	})
 
@@ -429,17 +389,15 @@ var _ = Describe(`VulnerabilityAdvisorV3 Integration Tests`, func() {
 			shouldSkipTest()
 		})
 		It(`ExemptionsAccountDeleteHandler(exemptionsAccountDeleteHandlerOptions *ExemptionsAccountDeleteHandlerOptions)`, func() {
-
-			exemptionsAccountDeleteHandlerOptions := &vulnerabilityadvisorv3.ExemptionsAccountDeleteHandlerOptions{}
+			exemptionsAccountDeleteHandlerOptions := &vulnerabilityadvisorv4.ExemptionsAccountDeleteHandlerOptions{}
 
 			exemptionDeletionInfo, response, err := vulnerabilityAdvisorService.ExemptionsAccountDeleteHandler(exemptionsAccountDeleteHandlerOptions)
-
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(exemptionDeletionInfo).ToNot(BeNil())
-
 		})
 	})
+
 })
 
 //

--- a/vulnerabilityadvisorv4/vulnerability_advisor_v4_suite_test.go
+++ b/vulnerabilityadvisorv4/vulnerability_advisor_v4_suite_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package vulnerabilityadvisorv3_test
+package vulnerabilityadvisorv4_test
 
 import (
 	"testing"
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestVulnerabilityAdvisorV3(t *testing.T) {
+func TestVulnerabilityAdvisorV4(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "VulnerabilityAdvisorV3 Suite")
+	RunSpecs(t, "VulnerabilityAdvisorV4 Suite")
 }

--- a/vulnerabilityadvisorv4/vulnerability_advisor_v4_test.go
+++ b/vulnerabilityadvisorv4/vulnerability_advisor_v4_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,49 +14,48 @@
  * limitations under the License.
  */
 
-package vulnerabilityadvisorv3_test
+package vulnerabilityadvisorv4_test
 
 import (
 	"bytes"
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"time"
 
-	"github.com/IBM/container-registry-go-sdk/vulnerabilityadvisorv3"
+	"github.com/IBM/container-registry-go-sdk/vulnerabilityadvisorv4"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/go-openapi/strfmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe(`VulnerabilityAdvisorV3`, func() {
+var _ = Describe(`VulnerabilityAdvisorV4`, func() {
 	var testServer *httptest.Server
 	Describe(`Service constructor tests`, func() {
 		account := "testString"
 		It(`Instantiate service client`, func() {
-			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
+			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
 				Authenticator: &core.NoAuthAuthenticator{},
-				Account:       core.StringPtr(account),
+				Account: core.StringPtr(account),
 			})
 			Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 			Expect(serviceErr).To(BeNil())
 		})
 		It(`Instantiate service client with error: Invalid URL`, func() {
-			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-				URL:     "{BAD_URL_STRING",
+			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+				URL: "{BAD_URL_STRING",
 				Account: core.StringPtr(account),
 			})
 			Expect(vulnerabilityAdvisorService).To(BeNil())
 			Expect(serviceErr).ToNot(BeNil())
 		})
 		It(`Instantiate service client with error: Invalid Auth`, func() {
-			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-				URL:     "https://vulnerabilityadvisorv3/api",
+			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+				URL: "https://vulnerabilityadvisorv4/api",
 				Account: core.StringPtr(account),
 				Authenticator: &core.BasicAuthenticator{
 					Username: "",
@@ -67,7 +66,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 			Expect(serviceErr).ToNot(BeNil())
 		})
 		It(`Instantiate service client with error: Validation Error`, func() {
-			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{})
+			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{})
 			Expect(vulnerabilityAdvisorService).To(BeNil())
 			Expect(serviceErr).ToNot(BeNil())
 		})
@@ -77,13 +76,13 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"VULNERABILITY_ADVISOR_URL":       "https://vulnerabilityadvisorv3/api",
+				"VULNERABILITY_ADVISOR_URL": "https://vulnerabilityadvisorv4/api",
 				"VULNERABILITY_ADVISOR_AUTH_TYPE": "noauth",
 			}
 
 			It(`Create service client using external config successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3UsingExternalConfig(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4UsingExternalConfig(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
 					Account: core.StringPtr(account),
 				})
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -98,8 +97,8 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 			})
 			It(`Create service client using external config and set url from constructor successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3UsingExternalConfig(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:     "https://testService/api",
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4UsingExternalConfig(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL: "https://testService/api",
 					Account: core.StringPtr(account),
 				})
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -115,7 +114,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 			})
 			It(`Create service client using external config and set url programatically successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3UsingExternalConfig(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4UsingExternalConfig(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
 					Account: core.StringPtr(account),
 				})
 				err := vulnerabilityAdvisorService.SetServiceURL("https://testService/api")
@@ -135,12 +134,12 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"VULNERABILITY_ADVISOR_URL":       "https://vulnerabilityadvisorv3/api",
+				"VULNERABILITY_ADVISOR_URL": "https://vulnerabilityadvisorv4/api",
 				"VULNERABILITY_ADVISOR_AUTH_TYPE": "someOtherAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
-			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3UsingExternalConfig(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
+			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4UsingExternalConfig(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
 				Account: core.StringPtr(account),
 			})
 
@@ -153,12 +152,12 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"VULNERABILITY_ADVISOR_AUTH_TYPE": "NOAuth",
+				"VULNERABILITY_ADVISOR_AUTH_TYPE":   "NOAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
-			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3UsingExternalConfig(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-				URL:     "{BAD_URL_STRING",
+			vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4UsingExternalConfig(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+				URL: "{BAD_URL_STRING",
 				Account: core.StringPtr(account),
 			})
 
@@ -173,60 +172,68 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		It(`GetServiceURLForRegion(region string)`, func() {
 			var url string
 			var err error
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("us-south")
-			Expect(url).To(Equal("https://us.icr.io"))
-			Expect(err).To(BeNil())
-
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("uk-south")
-			Expect(url).To(Equal("https://uk.icr.io"))
-			Expect(err).To(BeNil())
-
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("eu-gb")
-			Expect(url).To(Equal("https://uk.icr.io"))
-			Expect(err).To(BeNil())
-
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("eu-central")
-			Expect(url).To(Equal("https://de.icr.io"))
-			Expect(err).To(BeNil())
-
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("eu-de")
-			Expect(url).To(Equal("https://de.icr.io"))
-			Expect(err).To(BeNil())
-
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("ap-north")
-			Expect(url).To(Equal("https://jp.icr.io"))
-			Expect(err).To(BeNil())
-
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("jp-tok")
-			Expect(url).To(Equal("https://jp.icr.io"))
-			Expect(err).To(BeNil())
-
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("ap-south")
-			Expect(url).To(Equal("https://au.icr.io"))
-			Expect(err).To(BeNil())
-
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("au-syd")
-			Expect(url).To(Equal("https://au.icr.io"))
-			Expect(err).To(BeNil())
-
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("global")
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("global")
 			Expect(url).To(Equal("https://icr.io"))
 			Expect(err).To(BeNil())
 
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("jp-osa")
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("us-south")
+			Expect(url).To(Equal("https://us.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("uk-south")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("eu-gb")
+			Expect(url).To(Equal("https://uk.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("eu-central")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("eu-de")
+			Expect(url).To(Equal("https://de.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("ap-north")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("ap-south")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("au-syd")
+			Expect(url).To(Equal("https://au.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("jp-osa")
 			Expect(url).To(Equal("https://jp2.icr.io"))
 			Expect(err).To(BeNil())
 
-			url, err = vulnerabilityadvisorv3.GetServiceURLForRegion("INVALID_REGION")
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("br-sao")
+			Expect(url).To(Equal("https://br.icr.io"))
+			Expect(err).To(BeNil())
+
+			url, err = vulnerabilityadvisorv4.GetServiceURLForRegion("INVALID_REGION")
 			Expect(url).To(BeEmpty())
 			Expect(err).ToNot(BeNil())
 			fmt.Fprintf(GinkgoWriter, "Expected error: %s\n", err.Error())
 		})
 	})
 	Describe(`AccountReportQueryPath(accountReportQueryPathOptions *AccountReportQueryPathOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		accountReportQueryPathPath := "/va/api/v3/report/account"
+		account := "testString"
+		accountReportQueryPathPath := "/va/api/v4/report/account"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -244,21 +251,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.URL.Query()["includePrivate"]).To(Equal([]string{"testString"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke AccountReportQueryPath with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the AccountReportQueryPathOptions model
-				accountReportQueryPathOptionsModel := new(vulnerabilityadvisorv3.AccountReportQueryPathOptions)
+				accountReportQueryPathOptionsModel := new(vulnerabilityadvisorv4.AccountReportQueryPathOptions)
 				accountReportQueryPathOptionsModel.Repository = core.StringPtr("testString")
 				accountReportQueryPathOptionsModel.IncludeIBM = core.StringPtr("testString")
 				accountReportQueryPathOptionsModel.IncludePrivate = core.StringPtr("testString")
@@ -282,9 +289,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`AccountReportQueryPath(accountReportQueryPathOptions *AccountReportQueryPathOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		accountReportQueryPathPath := "/va/api/v3/report/account"
+		account := "testString"
+		accountReportQueryPathPath := "/va/api/v4/report/account"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -307,22 +314,22 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"assessments": {"mapKey": {"configuration_issues": [{"corrective_action": "CorrectiveAction", "description": "Description", "exempt": true, "meta": {"mapKey": "Inner"}, "type": "Type"}], "id": "ID", "scan_time": 8, "status": "Status", "vulnerabilities": [{"cve_exempt": false, "cve_id": "CveID", "exempt_security_notice_count": 25, "exempt_status": "ExemptStatus", "security_notice_count": 19, "security_notices": [{"notice": "Notice", "notice_exempt": true, "notice_id": "NoticeID", "summary": "Summary", "vulnerable_packages": [{"corrective_action": "CorrectiveAction", "description": "Description", "fix_version": "FixVersion", "installed_version": "InstalledVersion", "package_name": "PackageName"}]}], "summary": "Summary", "total_security_notice_count": 24}]}}}`)
+					fmt.Fprintf(res, "%s", `{"assessments": {"mapKey": {"configuration_issues": [{"corrective_action": "CorrectiveAction", "description": "Description", "exempt": true, "meta": {"mapKey": "Inner"}, "type": "Type"}], "id": "ID", "os_distribution": {"distribution_id": "debian", "version_id": "11", "version_code_name": "bullseye"}, "scan_time": 8, "status": "Status", "vulnerabilities": [{"cve_exempt": false, "cve_id": "CveID", "exempt_security_notice_count": 25, "exempt_status": "ExemptStatus", "security_notice_count": 19, "security_notices": [{"notice": "Notice", "notice_exempt": true, "notice_id": "NoticeID", "summary": "Summary", "vulnerable_packages": [{"corrective_action": "CorrectiveAction", "description": "Description", "fix_version": "FixVersion", "installed_version": "InstalledVersion", "package_name": "PackageName"}]}], "summary": "Summary", "total_security_notice_count": 24}]}}}`)
 				}))
 			})
 			It(`Invoke AccountReportQueryPath successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the AccountReportQueryPathOptions model
-				accountReportQueryPathOptionsModel := new(vulnerabilityadvisorv3.AccountReportQueryPathOptions)
+				accountReportQueryPathOptionsModel := new(vulnerabilityadvisorv4.AccountReportQueryPathOptions)
 				accountReportQueryPathOptionsModel.Repository = core.StringPtr("testString")
 				accountReportQueryPathOptionsModel.IncludeIBM = core.StringPtr("testString")
 				accountReportQueryPathOptionsModel.IncludePrivate = core.StringPtr("testString")
@@ -372,15 +379,15 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"assessments": {"mapKey": {"configuration_issues": [{"corrective_action": "CorrectiveAction", "description": "Description", "exempt": true, "meta": {"mapKey": "Inner"}, "type": "Type"}], "id": "ID", "scan_time": 8, "status": "Status", "vulnerabilities": [{"cve_exempt": false, "cve_id": "CveID", "exempt_security_notice_count": 25, "exempt_status": "ExemptStatus", "security_notice_count": 19, "security_notices": [{"notice": "Notice", "notice_exempt": true, "notice_id": "NoticeID", "summary": "Summary", "vulnerable_packages": [{"corrective_action": "CorrectiveAction", "description": "Description", "fix_version": "FixVersion", "installed_version": "InstalledVersion", "package_name": "PackageName"}]}], "summary": "Summary", "total_security_notice_count": 24}]}}}`)
+					fmt.Fprintf(res, "%s", `{"assessments": {"mapKey": {"configuration_issues": [{"corrective_action": "CorrectiveAction", "description": "Description", "exempt": true, "meta": {"mapKey": "Inner"}, "type": "Type"}], "id": "ID", "os_distribution": {"distribution_id": "debian", "version_id": "11", "version_code_name": "bullseye"}, "scan_time": 8, "status": "Status", "vulnerabilities": [{"cve_exempt": false, "cve_id": "CveID", "exempt_security_notice_count": 25, "exempt_status": "ExemptStatus", "security_notice_count": 19, "security_notices": [{"notice": "Notice", "notice_exempt": true, "notice_id": "NoticeID", "summary": "Summary", "vulnerable_packages": [{"corrective_action": "CorrectiveAction", "description": "Description", "fix_version": "FixVersion", "installed_version": "InstalledVersion", "package_name": "PackageName"}]}], "summary": "Summary", "total_security_notice_count": 24}]}}}`)
 				}))
 			})
 			It(`Invoke AccountReportQueryPath successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -392,7 +399,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the AccountReportQueryPathOptions model
-				accountReportQueryPathOptionsModel := new(vulnerabilityadvisorv3.AccountReportQueryPathOptions)
+				accountReportQueryPathOptionsModel := new(vulnerabilityadvisorv4.AccountReportQueryPathOptions)
 				accountReportQueryPathOptionsModel.Repository = core.StringPtr("testString")
 				accountReportQueryPathOptionsModel.IncludeIBM = core.StringPtr("testString")
 				accountReportQueryPathOptionsModel.IncludePrivate = core.StringPtr("testString")
@@ -406,17 +413,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke AccountReportQueryPath with error: Operation request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the AccountReportQueryPathOptions model
-				accountReportQueryPathOptionsModel := new(vulnerabilityadvisorv3.AccountReportQueryPathOptions)
+				accountReportQueryPathOptionsModel := new(vulnerabilityadvisorv4.AccountReportQueryPathOptions)
 				accountReportQueryPathOptionsModel.Repository = core.StringPtr("testString")
 				accountReportQueryPathOptionsModel.IncludeIBM = core.StringPtr("testString")
 				accountReportQueryPathOptionsModel.IncludePrivate = core.StringPtr("testString")
@@ -444,17 +451,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke AccountReportQueryPath successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the AccountReportQueryPathOptions model
-				accountReportQueryPathOptionsModel := new(vulnerabilityadvisorv3.AccountReportQueryPathOptions)
+				accountReportQueryPathOptionsModel := new(vulnerabilityadvisorv4.AccountReportQueryPathOptions)
 				accountReportQueryPathOptionsModel.Repository = core.StringPtr("testString")
 				accountReportQueryPathOptionsModel.IncludeIBM = core.StringPtr("testString")
 				accountReportQueryPathOptionsModel.IncludePrivate = core.StringPtr("testString")
@@ -474,9 +481,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`AccountStatusQueryPath(accountStatusQueryPathOptions *AccountStatusQueryPathOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		accountStatusQueryPathPath := "/va/api/v3/report/account/status"
+		account := "testString"
+		accountStatusQueryPathPath := "/va/api/v4/report/account/status"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -494,21 +501,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.URL.Query()["includePrivate"]).To(Equal([]string{"testString"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke AccountStatusQueryPath with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the AccountStatusQueryPathOptions model
-				accountStatusQueryPathOptionsModel := new(vulnerabilityadvisorv3.AccountStatusQueryPathOptions)
+				accountStatusQueryPathOptionsModel := new(vulnerabilityadvisorv4.AccountStatusQueryPathOptions)
 				accountStatusQueryPathOptionsModel.Repository = core.StringPtr("testString")
 				accountStatusQueryPathOptionsModel.IncludeIBM = core.StringPtr("testString")
 				accountStatusQueryPathOptionsModel.IncludePrivate = core.StringPtr("testString")
@@ -532,9 +539,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`AccountStatusQueryPath(accountStatusQueryPathOptions *AccountStatusQueryPathOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		accountStatusQueryPathPath := "/va/api/v3/report/account/status"
+		account := "testString"
+		accountStatusQueryPathPath := "/va/api/v4/report/account/status"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -561,18 +568,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke AccountStatusQueryPath successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the AccountStatusQueryPathOptions model
-				accountStatusQueryPathOptionsModel := new(vulnerabilityadvisorv3.AccountStatusQueryPathOptions)
+				accountStatusQueryPathOptionsModel := new(vulnerabilityadvisorv4.AccountStatusQueryPathOptions)
 				accountStatusQueryPathOptionsModel.Repository = core.StringPtr("testString")
 				accountStatusQueryPathOptionsModel.IncludeIBM = core.StringPtr("testString")
 				accountStatusQueryPathOptionsModel.IncludePrivate = core.StringPtr("testString")
@@ -626,11 +633,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke AccountStatusQueryPath successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -642,7 +649,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the AccountStatusQueryPathOptions model
-				accountStatusQueryPathOptionsModel := new(vulnerabilityadvisorv3.AccountStatusQueryPathOptions)
+				accountStatusQueryPathOptionsModel := new(vulnerabilityadvisorv4.AccountStatusQueryPathOptions)
 				accountStatusQueryPathOptionsModel.Repository = core.StringPtr("testString")
 				accountStatusQueryPathOptionsModel.IncludeIBM = core.StringPtr("testString")
 				accountStatusQueryPathOptionsModel.IncludePrivate = core.StringPtr("testString")
@@ -656,17 +663,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke AccountStatusQueryPath with error: Operation request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the AccountStatusQueryPathOptions model
-				accountStatusQueryPathOptionsModel := new(vulnerabilityadvisorv3.AccountStatusQueryPathOptions)
+				accountStatusQueryPathOptionsModel := new(vulnerabilityadvisorv4.AccountStatusQueryPathOptions)
 				accountStatusQueryPathOptionsModel.Repository = core.StringPtr("testString")
 				accountStatusQueryPathOptionsModel.IncludeIBM = core.StringPtr("testString")
 				accountStatusQueryPathOptionsModel.IncludePrivate = core.StringPtr("testString")
@@ -694,17 +701,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke AccountStatusQueryPath successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the AccountStatusQueryPathOptions model
-				accountStatusQueryPathOptionsModel := new(vulnerabilityadvisorv3.AccountStatusQueryPathOptions)
+				accountStatusQueryPathOptionsModel := new(vulnerabilityadvisorv4.AccountStatusQueryPathOptions)
 				accountStatusQueryPathOptionsModel.Repository = core.StringPtr("testString")
 				accountStatusQueryPathOptionsModel.IncludeIBM = core.StringPtr("testString")
 				accountStatusQueryPathOptionsModel.IncludePrivate = core.StringPtr("testString")
@@ -724,9 +731,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ImageReportQueryPath(imageReportQueryPathOptions *ImageReportQueryPathOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		imageReportQueryPathPath := "/va/api/v3/report/image/testString"
+		account := "testString"
+		imageReportQueryPathPath := "/va/api/v4/report/image/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -741,21 +748,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ImageReportQueryPath with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ImageReportQueryPathOptions model
-				imageReportQueryPathOptionsModel := new(vulnerabilityadvisorv3.ImageReportQueryPathOptions)
+				imageReportQueryPathOptionsModel := new(vulnerabilityadvisorv4.ImageReportQueryPathOptions)
 				imageReportQueryPathOptionsModel.Name = core.StringPtr("testString")
 				imageReportQueryPathOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -777,9 +784,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ImageReportQueryPath(imageReportQueryPathOptions *ImageReportQueryPathOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		imageReportQueryPathPath := "/va/api/v3/report/image/testString"
+		account := "testString"
+		imageReportQueryPathPath := "/va/api/v4/report/image/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -799,22 +806,22 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"configuration_issues": [{"corrective_action": "CorrectiveAction", "description": "Description", "exempt": true, "meta": {"mapKey": "Inner"}, "type": "Type"}], "id": "ID", "scan_time": 8, "status": "Status", "vulnerabilities": [{"cve_exempt": false, "cve_id": "CveID", "exempt_security_notice_count": 25, "exempt_status": "ExemptStatus", "security_notice_count": 19, "security_notices": [{"notice": "Notice", "notice_exempt": true, "notice_id": "NoticeID", "summary": "Summary", "vulnerable_packages": [{"corrective_action": "CorrectiveAction", "description": "Description", "fix_version": "FixVersion", "installed_version": "InstalledVersion", "package_name": "PackageName"}]}], "summary": "Summary", "total_security_notice_count": 24}]}`)
+					fmt.Fprintf(res, "%s", `{"configuration_issues": [{"corrective_action": "CorrectiveAction", "description": "Description", "exempt": true, "meta": {"mapKey": "Inner"}, "type": "Type"}], "id": "ID", "os_distribution": {"distribution_id": "debian", "version_id": "11", "version_code_name": "bullseye"}, "scan_time": 8, "status": "Status", "vulnerabilities": [{"cve_exempt": false, "cve_id": "CveID", "exempt_security_notice_count": 25, "exempt_status": "ExemptStatus", "security_notice_count": 19, "security_notices": [{"notice": "Notice", "notice_exempt": true, "notice_id": "NoticeID", "summary": "Summary", "vulnerable_packages": [{"corrective_action": "CorrectiveAction", "description": "Description", "fix_version": "FixVersion", "installed_version": "InstalledVersion", "package_name": "PackageName"}]}], "summary": "Summary", "total_security_notice_count": 24}]}`)
 				}))
 			})
 			It(`Invoke ImageReportQueryPath successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the ImageReportQueryPathOptions model
-				imageReportQueryPathOptionsModel := new(vulnerabilityadvisorv3.ImageReportQueryPathOptions)
+				imageReportQueryPathOptionsModel := new(vulnerabilityadvisorv4.ImageReportQueryPathOptions)
 				imageReportQueryPathOptionsModel.Name = core.StringPtr("testString")
 				imageReportQueryPathOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -859,15 +866,15 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"configuration_issues": [{"corrective_action": "CorrectiveAction", "description": "Description", "exempt": true, "meta": {"mapKey": "Inner"}, "type": "Type"}], "id": "ID", "scan_time": 8, "status": "Status", "vulnerabilities": [{"cve_exempt": false, "cve_id": "CveID", "exempt_security_notice_count": 25, "exempt_status": "ExemptStatus", "security_notice_count": 19, "security_notices": [{"notice": "Notice", "notice_exempt": true, "notice_id": "NoticeID", "summary": "Summary", "vulnerable_packages": [{"corrective_action": "CorrectiveAction", "description": "Description", "fix_version": "FixVersion", "installed_version": "InstalledVersion", "package_name": "PackageName"}]}], "summary": "Summary", "total_security_notice_count": 24}]}`)
+					fmt.Fprintf(res, "%s", `{"configuration_issues": [{"corrective_action": "CorrectiveAction", "description": "Description", "exempt": true, "meta": {"mapKey": "Inner"}, "type": "Type"}], "id": "ID", "os_distribution": {"distribution_id": "debian", "version_id": "11", "version_code_name": "bullseye"}, "scan_time": 8, "status": "Status", "vulnerabilities": [{"cve_exempt": false, "cve_id": "CveID", "exempt_security_notice_count": 25, "exempt_status": "ExemptStatus", "security_notice_count": 19, "security_notices": [{"notice": "Notice", "notice_exempt": true, "notice_id": "NoticeID", "summary": "Summary", "vulnerable_packages": [{"corrective_action": "CorrectiveAction", "description": "Description", "fix_version": "FixVersion", "installed_version": "InstalledVersion", "package_name": "PackageName"}]}], "summary": "Summary", "total_security_notice_count": 24}]}`)
 				}))
 			})
 			It(`Invoke ImageReportQueryPath successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -879,7 +886,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the ImageReportQueryPathOptions model
-				imageReportQueryPathOptionsModel := new(vulnerabilityadvisorv3.ImageReportQueryPathOptions)
+				imageReportQueryPathOptionsModel := new(vulnerabilityadvisorv4.ImageReportQueryPathOptions)
 				imageReportQueryPathOptionsModel.Name = core.StringPtr("testString")
 				imageReportQueryPathOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -891,17 +898,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke ImageReportQueryPath with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ImageReportQueryPathOptions model
-				imageReportQueryPathOptionsModel := new(vulnerabilityadvisorv3.ImageReportQueryPathOptions)
+				imageReportQueryPathOptionsModel := new(vulnerabilityadvisorv4.ImageReportQueryPathOptions)
 				imageReportQueryPathOptionsModel.Name = core.StringPtr("testString")
 				imageReportQueryPathOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -913,7 +920,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 				// Construct a second instance of the ImageReportQueryPathOptions model with no property values
-				imageReportQueryPathOptionsModelNew := new(vulnerabilityadvisorv3.ImageReportQueryPathOptions)
+				imageReportQueryPathOptionsModelNew := new(vulnerabilityadvisorv4.ImageReportQueryPathOptions)
 				// Invoke operation with invalid model (negative test)
 				result, response, operationErr = vulnerabilityAdvisorService.ImageReportQueryPath(imageReportQueryPathOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -934,17 +941,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ImageReportQueryPath successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ImageReportQueryPathOptions model
-				imageReportQueryPathOptionsModel := new(vulnerabilityadvisorv3.ImageReportQueryPathOptions)
+				imageReportQueryPathOptionsModel := new(vulnerabilityadvisorv4.ImageReportQueryPathOptions)
 				imageReportQueryPathOptionsModel.Name = core.StringPtr("testString")
 				imageReportQueryPathOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -962,9 +969,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ImageStatusQueryPath(imageStatusQueryPathOptions *ImageStatusQueryPathOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		imageStatusQueryPathPath := "/va/api/v3/report/image/status/testString"
+		account := "testString"
+		imageStatusQueryPathPath := "/va/api/v4/report/image/status/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -979,21 +986,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ImageStatusQueryPath with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ImageStatusQueryPathOptions model
-				imageStatusQueryPathOptionsModel := new(vulnerabilityadvisorv3.ImageStatusQueryPathOptions)
+				imageStatusQueryPathOptionsModel := new(vulnerabilityadvisorv4.ImageStatusQueryPathOptions)
 				imageStatusQueryPathOptionsModel.Name = core.StringPtr("testString")
 				imageStatusQueryPathOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -1015,9 +1022,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ImageStatusQueryPath(imageStatusQueryPathOptions *ImageStatusQueryPathOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		imageStatusQueryPathPath := "/va/api/v3/report/image/status/testString"
+		account := "testString"
+		imageStatusQueryPathPath := "/va/api/v4/report/image/status/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1041,18 +1048,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ImageStatusQueryPath successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the ImageStatusQueryPathOptions model
-				imageStatusQueryPathOptionsModel := new(vulnerabilityadvisorv3.ImageStatusQueryPathOptions)
+				imageStatusQueryPathOptionsModel := new(vulnerabilityadvisorv4.ImageStatusQueryPathOptions)
 				imageStatusQueryPathOptionsModel.Name = core.StringPtr("testString")
 				imageStatusQueryPathOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1101,11 +1108,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ImageStatusQueryPath successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -1117,7 +1124,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the ImageStatusQueryPathOptions model
-				imageStatusQueryPathOptionsModel := new(vulnerabilityadvisorv3.ImageStatusQueryPathOptions)
+				imageStatusQueryPathOptionsModel := new(vulnerabilityadvisorv4.ImageStatusQueryPathOptions)
 				imageStatusQueryPathOptionsModel.Name = core.StringPtr("testString")
 				imageStatusQueryPathOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1129,17 +1136,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke ImageStatusQueryPath with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ImageStatusQueryPathOptions model
-				imageStatusQueryPathOptionsModel := new(vulnerabilityadvisorv3.ImageStatusQueryPathOptions)
+				imageStatusQueryPathOptionsModel := new(vulnerabilityadvisorv4.ImageStatusQueryPathOptions)
 				imageStatusQueryPathOptionsModel.Name = core.StringPtr("testString")
 				imageStatusQueryPathOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -1151,7 +1158,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 				// Construct a second instance of the ImageStatusQueryPathOptions model with no property values
-				imageStatusQueryPathOptionsModelNew := new(vulnerabilityadvisorv3.ImageStatusQueryPathOptions)
+				imageStatusQueryPathOptionsModelNew := new(vulnerabilityadvisorv4.ImageStatusQueryPathOptions)
 				// Invoke operation with invalid model (negative test)
 				result, response, operationErr = vulnerabilityAdvisorService.ImageStatusQueryPath(imageStatusQueryPathOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -1172,17 +1179,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ImageStatusQueryPath successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ImageStatusQueryPathOptions model
-				imageStatusQueryPathOptionsModel := new(vulnerabilityadvisorv3.ImageStatusQueryPathOptions)
+				imageStatusQueryPathOptionsModel := new(vulnerabilityadvisorv4.ImageStatusQueryPathOptions)
 				imageStatusQueryPathOptionsModel.Name = core.StringPtr("testString")
 				imageStatusQueryPathOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1200,9 +1207,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ListExemptionAccount(listExemptionAccountOptions *ListExemptionAccountOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		listExemptionAccountPath := "/va/api/v3/exempt/image"
+		account := "testString"
+		listExemptionAccountPath := "/va/api/v4/exempt/image"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1217,21 +1224,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListExemptionAccount with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListExemptionAccountOptions model
-				listExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.ListExemptionAccountOptions)
+				listExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.ListExemptionAccountOptions)
 				listExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := vulnerabilityAdvisorService.ListExemptionAccount(listExemptionAccountOptionsModel)
@@ -1252,9 +1259,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ListExemptionAccount(listExemptionAccountOptions *ListExemptionAccountOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		listExemptionAccountPath := "/va/api/v3/exempt/image"
+		account := "testString"
+		listExemptionAccountPath := "/va/api/v4/exempt/image"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1278,18 +1285,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListExemptionAccount successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the ListExemptionAccountOptions model
-				listExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.ListExemptionAccountOptions)
+				listExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.ListExemptionAccountOptions)
 				listExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -1337,11 +1344,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListExemptionAccount successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -1353,7 +1360,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the ListExemptionAccountOptions model
-				listExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.ListExemptionAccountOptions)
+				listExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.ListExemptionAccountOptions)
 				listExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -1364,17 +1371,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke ListExemptionAccount with error: Operation request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListExemptionAccountOptions model
-				listExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.ListExemptionAccountOptions)
+				listExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.ListExemptionAccountOptions)
 				listExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := vulnerabilityAdvisorService.SetServiceURL("")
@@ -1399,17 +1406,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListExemptionAccount successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListExemptionAccountOptions model
-				listExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.ListExemptionAccountOptions)
+				listExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.ListExemptionAccountOptions)
 				listExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -1426,9 +1433,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`GetExemptionAccount(getExemptionAccountOptions *GetExemptionAccountOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		getExemptionAccountPath := "/va/api/v3/exempt/image/issue/testString/testString"
+		account := "testString"
+		getExemptionAccountPath := "/va/api/v4/exempt/image/issue/testString/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1443,21 +1450,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetExemptionAccount with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the GetExemptionAccountOptions model
-				getExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.GetExemptionAccountOptions)
+				getExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.GetExemptionAccountOptions)
 				getExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				getExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				getExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1480,9 +1487,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`GetExemptionAccount(getExemptionAccountOptions *GetExemptionAccountOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		getExemptionAccountPath := "/va/api/v3/exempt/image/issue/testString/testString"
+		account := "testString"
+		getExemptionAccountPath := "/va/api/v4/exempt/image/issue/testString/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1506,18 +1513,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke GetExemptionAccount successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the GetExemptionAccountOptions model
-				getExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.GetExemptionAccountOptions)
+				getExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.GetExemptionAccountOptions)
 				getExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				getExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				getExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1567,11 +1574,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke GetExemptionAccount successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -1583,7 +1590,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the GetExemptionAccountOptions model
-				getExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.GetExemptionAccountOptions)
+				getExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.GetExemptionAccountOptions)
 				getExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				getExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				getExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1596,17 +1603,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke GetExemptionAccount with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the GetExemptionAccountOptions model
-				getExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.GetExemptionAccountOptions)
+				getExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.GetExemptionAccountOptions)
 				getExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				getExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				getExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1619,7 +1626,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 				// Construct a second instance of the GetExemptionAccountOptions model with no property values
-				getExemptionAccountOptionsModelNew := new(vulnerabilityadvisorv3.GetExemptionAccountOptions)
+				getExemptionAccountOptionsModelNew := new(vulnerabilityadvisorv4.GetExemptionAccountOptions)
 				// Invoke operation with invalid model (negative test)
 				result, response, operationErr = vulnerabilityAdvisorService.GetExemptionAccount(getExemptionAccountOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -1640,17 +1647,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke GetExemptionAccount successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the GetExemptionAccountOptions model
-				getExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.GetExemptionAccountOptions)
+				getExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.GetExemptionAccountOptions)
 				getExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				getExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				getExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1669,9 +1676,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`CreateExemptionAccount(createExemptionAccountOptions *CreateExemptionAccountOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		createExemptionAccountPath := "/va/api/v3/exempt/image/issue/testString/testString"
+		account := "testString"
+		createExemptionAccountPath := "/va/api/v4/exempt/image/issue/testString/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1686,21 +1693,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke CreateExemptionAccount with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the CreateExemptionAccountOptions model
-				createExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.CreateExemptionAccountOptions)
+				createExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.CreateExemptionAccountOptions)
 				createExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				createExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				createExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1723,9 +1730,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`CreateExemptionAccount(createExemptionAccountOptions *CreateExemptionAccountOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		createExemptionAccountPath := "/va/api/v3/exempt/image/issue/testString/testString"
+		account := "testString"
+		createExemptionAccountPath := "/va/api/v4/exempt/image/issue/testString/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1749,18 +1756,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke CreateExemptionAccount successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the CreateExemptionAccountOptions model
-				createExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.CreateExemptionAccountOptions)
+				createExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.CreateExemptionAccountOptions)
 				createExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				createExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				createExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1810,11 +1817,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke CreateExemptionAccount successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -1826,7 +1833,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the CreateExemptionAccountOptions model
-				createExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.CreateExemptionAccountOptions)
+				createExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.CreateExemptionAccountOptions)
 				createExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				createExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				createExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1839,17 +1846,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke CreateExemptionAccount with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the CreateExemptionAccountOptions model
-				createExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.CreateExemptionAccountOptions)
+				createExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.CreateExemptionAccountOptions)
 				createExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				createExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				createExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1862,7 +1869,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 				// Construct a second instance of the CreateExemptionAccountOptions model with no property values
-				createExemptionAccountOptionsModelNew := new(vulnerabilityadvisorv3.CreateExemptionAccountOptions)
+				createExemptionAccountOptionsModelNew := new(vulnerabilityadvisorv4.CreateExemptionAccountOptions)
 				// Invoke operation with invalid model (negative test)
 				result, response, operationErr = vulnerabilityAdvisorService.CreateExemptionAccount(createExemptionAccountOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -1883,17 +1890,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke CreateExemptionAccount successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the CreateExemptionAccountOptions model
-				createExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.CreateExemptionAccountOptions)
+				createExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.CreateExemptionAccountOptions)
 				createExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				createExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				createExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1912,9 +1919,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`DeleteExemptionAccount(deleteExemptionAccountOptions *DeleteExemptionAccountOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		deleteExemptionAccountPath := "/va/api/v3/exempt/image/issue/testString/testString"
+		account := "testString"
+		deleteExemptionAccountPath := "/va/api/v4/exempt/image/issue/testString/testString"
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1932,11 +1939,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke DeleteExemptionAccount successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -1947,7 +1954,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 
 				// Construct an instance of the DeleteExemptionAccountOptions model
-				deleteExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.DeleteExemptionAccountOptions)
+				deleteExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.DeleteExemptionAccountOptions)
 				deleteExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				deleteExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				deleteExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1958,17 +1965,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).ToNot(BeNil())
 			})
 			It(`Invoke DeleteExemptionAccount with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the DeleteExemptionAccountOptions model
-				deleteExemptionAccountOptionsModel := new(vulnerabilityadvisorv3.DeleteExemptionAccountOptions)
+				deleteExemptionAccountOptionsModel := new(vulnerabilityadvisorv4.DeleteExemptionAccountOptions)
 				deleteExemptionAccountOptionsModel.IssueType = core.StringPtr("testString")
 				deleteExemptionAccountOptionsModel.IssueID = core.StringPtr("testString")
 				deleteExemptionAccountOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1980,7 +1987,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
 				Expect(response).To(BeNil())
 				// Construct a second instance of the DeleteExemptionAccountOptions model with no property values
-				deleteExemptionAccountOptionsModelNew := new(vulnerabilityadvisorv3.DeleteExemptionAccountOptions)
+				deleteExemptionAccountOptionsModelNew := new(vulnerabilityadvisorv4.DeleteExemptionAccountOptions)
 				// Invoke operation with invalid model (negative test)
 				response, operationErr = vulnerabilityAdvisorService.DeleteExemptionAccount(deleteExemptionAccountOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -1992,9 +1999,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ListExemptionResource(listExemptionResourceOptions *ListExemptionResourceOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		listExemptionResourcePath := "/va/api/v3/exempt/image/testString"
+		account := "testString"
+		listExemptionResourcePath := "/va/api/v4/exempt/image/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2009,21 +2016,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListExemptionResource with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListExemptionResourceOptions model
-				listExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.ListExemptionResourceOptions)
+				listExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.ListExemptionResourceOptions)
 				listExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				listExemptionResourceOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -2045,9 +2052,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ListExemptionResource(listExemptionResourceOptions *ListExemptionResourceOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		listExemptionResourcePath := "/va/api/v3/exempt/image/testString"
+		account := "testString"
+		listExemptionResourcePath := "/va/api/v4/exempt/image/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2071,18 +2078,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListExemptionResource successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the ListExemptionResourceOptions model
-				listExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.ListExemptionResourceOptions)
+				listExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.ListExemptionResourceOptions)
 				listExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				listExemptionResourceOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2131,11 +2138,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListExemptionResource successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -2147,7 +2154,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the ListExemptionResourceOptions model
-				listExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.ListExemptionResourceOptions)
+				listExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.ListExemptionResourceOptions)
 				listExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				listExemptionResourceOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2159,17 +2166,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke ListExemptionResource with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListExemptionResourceOptions model
-				listExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.ListExemptionResourceOptions)
+				listExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.ListExemptionResourceOptions)
 				listExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				listExemptionResourceOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -2181,7 +2188,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 				// Construct a second instance of the ListExemptionResourceOptions model with no property values
-				listExemptionResourceOptionsModelNew := new(vulnerabilityadvisorv3.ListExemptionResourceOptions)
+				listExemptionResourceOptionsModelNew := new(vulnerabilityadvisorv4.ListExemptionResourceOptions)
 				// Invoke operation with invalid model (negative test)
 				result, response, operationErr = vulnerabilityAdvisorService.ListExemptionResource(listExemptionResourceOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -2202,17 +2209,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListExemptionResource successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListExemptionResourceOptions model
-				listExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.ListExemptionResourceOptions)
+				listExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.ListExemptionResourceOptions)
 				listExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				listExemptionResourceOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2230,9 +2237,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`GetExemptionResource(getExemptionResourceOptions *GetExemptionResourceOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		getExemptionResourcePath := "/va/api/v3/exempt/image/testString/issue/testString/testString"
+		account := "testString"
+		getExemptionResourcePath := "/va/api/v4/exempt/image/testString/issue/testString/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2247,21 +2254,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetExemptionResource with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the GetExemptionResourceOptions model
-				getExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.GetExemptionResourceOptions)
+				getExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.GetExemptionResourceOptions)
 				getExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				getExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				getExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2285,9 +2292,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`GetExemptionResource(getExemptionResourceOptions *GetExemptionResourceOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		getExemptionResourcePath := "/va/api/v3/exempt/image/testString/issue/testString/testString"
+		account := "testString"
+		getExemptionResourcePath := "/va/api/v4/exempt/image/testString/issue/testString/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2311,18 +2318,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke GetExemptionResource successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the GetExemptionResourceOptions model
-				getExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.GetExemptionResourceOptions)
+				getExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.GetExemptionResourceOptions)
 				getExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				getExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				getExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2373,11 +2380,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke GetExemptionResource successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -2389,7 +2396,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the GetExemptionResourceOptions model
-				getExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.GetExemptionResourceOptions)
+				getExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.GetExemptionResourceOptions)
 				getExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				getExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				getExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2403,17 +2410,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke GetExemptionResource with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the GetExemptionResourceOptions model
-				getExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.GetExemptionResourceOptions)
+				getExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.GetExemptionResourceOptions)
 				getExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				getExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				getExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2427,7 +2434,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 				// Construct a second instance of the GetExemptionResourceOptions model with no property values
-				getExemptionResourceOptionsModelNew := new(vulnerabilityadvisorv3.GetExemptionResourceOptions)
+				getExemptionResourceOptionsModelNew := new(vulnerabilityadvisorv4.GetExemptionResourceOptions)
 				// Invoke operation with invalid model (negative test)
 				result, response, operationErr = vulnerabilityAdvisorService.GetExemptionResource(getExemptionResourceOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -2448,17 +2455,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke GetExemptionResource successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the GetExemptionResourceOptions model
-				getExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.GetExemptionResourceOptions)
+				getExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.GetExemptionResourceOptions)
 				getExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				getExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				getExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2478,9 +2485,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`CreateExemptionResource(createExemptionResourceOptions *CreateExemptionResourceOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		createExemptionResourcePath := "/va/api/v3/exempt/image/testString/issue/testString/testString"
+		account := "testString"
+		createExemptionResourcePath := "/va/api/v4/exempt/image/testString/issue/testString/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2495,21 +2502,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke CreateExemptionResource with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the CreateExemptionResourceOptions model
-				createExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.CreateExemptionResourceOptions)
+				createExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.CreateExemptionResourceOptions)
 				createExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				createExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				createExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2533,9 +2540,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`CreateExemptionResource(createExemptionResourceOptions *CreateExemptionResourceOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		createExemptionResourcePath := "/va/api/v3/exempt/image/testString/issue/testString/testString"
+		account := "testString"
+		createExemptionResourcePath := "/va/api/v4/exempt/image/testString/issue/testString/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2559,18 +2566,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke CreateExemptionResource successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the CreateExemptionResourceOptions model
-				createExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.CreateExemptionResourceOptions)
+				createExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.CreateExemptionResourceOptions)
 				createExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				createExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				createExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2621,11 +2628,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke CreateExemptionResource successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -2637,7 +2644,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the CreateExemptionResourceOptions model
-				createExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.CreateExemptionResourceOptions)
+				createExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.CreateExemptionResourceOptions)
 				createExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				createExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				createExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2651,17 +2658,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke CreateExemptionResource with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the CreateExemptionResourceOptions model
-				createExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.CreateExemptionResourceOptions)
+				createExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.CreateExemptionResourceOptions)
 				createExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				createExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				createExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2675,7 +2682,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 				// Construct a second instance of the CreateExemptionResourceOptions model with no property values
-				createExemptionResourceOptionsModelNew := new(vulnerabilityadvisorv3.CreateExemptionResourceOptions)
+				createExemptionResourceOptionsModelNew := new(vulnerabilityadvisorv4.CreateExemptionResourceOptions)
 				// Invoke operation with invalid model (negative test)
 				result, response, operationErr = vulnerabilityAdvisorService.CreateExemptionResource(createExemptionResourceOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -2696,17 +2703,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke CreateExemptionResource successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the CreateExemptionResourceOptions model
-				createExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.CreateExemptionResourceOptions)
+				createExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.CreateExemptionResourceOptions)
 				createExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				createExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				createExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2726,9 +2733,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`DeleteExemptionResource(deleteExemptionResourceOptions *DeleteExemptionResourceOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		deleteExemptionResourcePath := "/va/api/v3/exempt/image/testString/issue/testString/testString"
+		account := "testString"
+		deleteExemptionResourcePath := "/va/api/v4/exempt/image/testString/issue/testString/testString"
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2746,11 +2753,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke DeleteExemptionResource successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -2761,7 +2768,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 
 				// Construct an instance of the DeleteExemptionResourceOptions model
-				deleteExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.DeleteExemptionResourceOptions)
+				deleteExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.DeleteExemptionResourceOptions)
 				deleteExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				deleteExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				deleteExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2773,17 +2780,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).ToNot(BeNil())
 			})
 			It(`Invoke DeleteExemptionResource with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the DeleteExemptionResourceOptions model
-				deleteExemptionResourceOptionsModel := new(vulnerabilityadvisorv3.DeleteExemptionResourceOptions)
+				deleteExemptionResourceOptionsModel := new(vulnerabilityadvisorv4.DeleteExemptionResourceOptions)
 				deleteExemptionResourceOptionsModel.Resource = core.StringPtr("testString")
 				deleteExemptionResourceOptionsModel.IssueType = core.StringPtr("testString")
 				deleteExemptionResourceOptionsModel.IssueID = core.StringPtr("testString")
@@ -2796,7 +2803,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
 				Expect(response).To(BeNil())
 				// Construct a second instance of the DeleteExemptionResourceOptions model with no property values
-				deleteExemptionResourceOptionsModelNew := new(vulnerabilityadvisorv3.DeleteExemptionResourceOptions)
+				deleteExemptionResourceOptionsModelNew := new(vulnerabilityadvisorv4.DeleteExemptionResourceOptions)
 				// Invoke operation with invalid model (negative test)
 				response, operationErr = vulnerabilityAdvisorService.DeleteExemptionResource(deleteExemptionResourceOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -2808,9 +2815,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ExemptHandler(exemptHandlerOptions *ExemptHandlerOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		exemptHandlerPath := "/va/api/v3/exempt/types"
+		account := "testString"
+		exemptHandlerPath := "/va/api/v4/exempt/types"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2825,21 +2832,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ExemptHandler with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ExemptHandlerOptions model
-				exemptHandlerOptionsModel := new(vulnerabilityadvisorv3.ExemptHandlerOptions)
+				exemptHandlerOptionsModel := new(vulnerabilityadvisorv4.ExemptHandlerOptions)
 				exemptHandlerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := vulnerabilityAdvisorService.ExemptHandler(exemptHandlerOptionsModel)
@@ -2860,9 +2867,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ExemptHandler(exemptHandlerOptions *ExemptHandlerOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		exemptHandlerPath := "/va/api/v3/exempt/types"
+		account := "testString"
+		exemptHandlerPath := "/va/api/v4/exempt/types"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2886,18 +2893,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ExemptHandler successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the ExemptHandlerOptions model
-				exemptHandlerOptionsModel := new(vulnerabilityadvisorv3.ExemptHandlerOptions)
+				exemptHandlerOptionsModel := new(vulnerabilityadvisorv4.ExemptHandlerOptions)
 				exemptHandlerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -2945,11 +2952,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ExemptHandler successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -2961,7 +2968,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the ExemptHandlerOptions model
-				exemptHandlerOptionsModel := new(vulnerabilityadvisorv3.ExemptHandlerOptions)
+				exemptHandlerOptionsModel := new(vulnerabilityadvisorv4.ExemptHandlerOptions)
 				exemptHandlerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -2972,17 +2979,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke ExemptHandler with error: Operation request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ExemptHandlerOptions model
-				exemptHandlerOptionsModel := new(vulnerabilityadvisorv3.ExemptHandlerOptions)
+				exemptHandlerOptionsModel := new(vulnerabilityadvisorv4.ExemptHandlerOptions)
 				exemptHandlerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := vulnerabilityAdvisorService.SetServiceURL("")
@@ -3007,17 +3014,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ExemptHandler successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ExemptHandlerOptions model
-				exemptHandlerOptionsModel := new(vulnerabilityadvisorv3.ExemptHandlerOptions)
+				exemptHandlerOptionsModel := new(vulnerabilityadvisorv4.ExemptHandlerOptions)
 				exemptHandlerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -3034,9 +3041,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ListAccountExemptions(listAccountExemptionsOptions *ListAccountExemptionsOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		listAccountExemptionsPath := "/va/api/v3/exemptions/account"
+		account := "testString"
+		listAccountExemptionsPath := "/va/api/v4/exemptions/account"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3051,21 +3058,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListAccountExemptions with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListAccountExemptionsOptions model
-				listAccountExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListAccountExemptionsOptions)
+				listAccountExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListAccountExemptionsOptions)
 				listAccountExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := vulnerabilityAdvisorService.ListAccountExemptions(listAccountExemptionsOptionsModel)
@@ -3086,9 +3093,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ListAccountExemptions(listAccountExemptionsOptions *ListAccountExemptionsOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		listAccountExemptionsPath := "/va/api/v3/exemptions/account"
+		account := "testString"
+		listAccountExemptionsPath := "/va/api/v4/exemptions/account"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3112,18 +3119,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListAccountExemptions successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the ListAccountExemptionsOptions model
-				listAccountExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListAccountExemptionsOptions)
+				listAccountExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListAccountExemptionsOptions)
 				listAccountExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -3171,11 +3178,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListAccountExemptions successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -3187,7 +3194,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the ListAccountExemptionsOptions model
-				listAccountExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListAccountExemptionsOptions)
+				listAccountExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListAccountExemptionsOptions)
 				listAccountExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -3198,17 +3205,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke ListAccountExemptions with error: Operation request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListAccountExemptionsOptions model
-				listAccountExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListAccountExemptionsOptions)
+				listAccountExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListAccountExemptionsOptions)
 				listAccountExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := vulnerabilityAdvisorService.SetServiceURL("")
@@ -3233,17 +3240,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListAccountExemptions successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListAccountExemptionsOptions model
-				listAccountExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListAccountExemptionsOptions)
+				listAccountExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListAccountExemptionsOptions)
 				listAccountExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -3260,9 +3267,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ExemptionsAccountDeleteHandler(exemptionsAccountDeleteHandlerOptions *ExemptionsAccountDeleteHandlerOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		exemptionsAccountDeleteHandlerPath := "/va/api/v3/exemptions/deleteAll"
+		account := "testString"
+		exemptionsAccountDeleteHandlerPath := "/va/api/v4/exemptions/deleteAll"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3277,21 +3284,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ExemptionsAccountDeleteHandler with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ExemptionsAccountDeleteHandlerOptions model
-				exemptionsAccountDeleteHandlerOptionsModel := new(vulnerabilityadvisorv3.ExemptionsAccountDeleteHandlerOptions)
+				exemptionsAccountDeleteHandlerOptionsModel := new(vulnerabilityadvisorv4.ExemptionsAccountDeleteHandlerOptions)
 				exemptionsAccountDeleteHandlerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := vulnerabilityAdvisorService.ExemptionsAccountDeleteHandler(exemptionsAccountDeleteHandlerOptionsModel)
@@ -3312,9 +3319,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ExemptionsAccountDeleteHandler(exemptionsAccountDeleteHandlerOptions *ExemptionsAccountDeleteHandlerOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		exemptionsAccountDeleteHandlerPath := "/va/api/v3/exemptions/deleteAll"
+		account := "testString"
+		exemptionsAccountDeleteHandlerPath := "/va/api/v4/exemptions/deleteAll"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3338,18 +3345,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ExemptionsAccountDeleteHandler successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the ExemptionsAccountDeleteHandlerOptions model
-				exemptionsAccountDeleteHandlerOptionsModel := new(vulnerabilityadvisorv3.ExemptionsAccountDeleteHandlerOptions)
+				exemptionsAccountDeleteHandlerOptionsModel := new(vulnerabilityadvisorv4.ExemptionsAccountDeleteHandlerOptions)
 				exemptionsAccountDeleteHandlerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -3397,11 +3404,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ExemptionsAccountDeleteHandler successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -3413,7 +3420,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the ExemptionsAccountDeleteHandlerOptions model
-				exemptionsAccountDeleteHandlerOptionsModel := new(vulnerabilityadvisorv3.ExemptionsAccountDeleteHandlerOptions)
+				exemptionsAccountDeleteHandlerOptionsModel := new(vulnerabilityadvisorv4.ExemptionsAccountDeleteHandlerOptions)
 				exemptionsAccountDeleteHandlerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -3424,17 +3431,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke ExemptionsAccountDeleteHandler with error: Operation request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ExemptionsAccountDeleteHandlerOptions model
-				exemptionsAccountDeleteHandlerOptionsModel := new(vulnerabilityadvisorv3.ExemptionsAccountDeleteHandlerOptions)
+				exemptionsAccountDeleteHandlerOptionsModel := new(vulnerabilityadvisorv4.ExemptionsAccountDeleteHandlerOptions)
 				exemptionsAccountDeleteHandlerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := vulnerabilityAdvisorService.SetServiceURL("")
@@ -3459,17 +3466,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ExemptionsAccountDeleteHandler successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ExemptionsAccountDeleteHandlerOptions model
-				exemptionsAccountDeleteHandlerOptionsModel := new(vulnerabilityadvisorv3.ExemptionsAccountDeleteHandlerOptions)
+				exemptionsAccountDeleteHandlerOptionsModel := new(vulnerabilityadvisorv4.ExemptionsAccountDeleteHandlerOptions)
 				exemptionsAccountDeleteHandlerOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -3486,9 +3493,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ListImageExemptions(listImageExemptionsOptions *ListImageExemptionsOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		listImageExemptionsPath := "/va/api/v3/exemptions/image/testString"
+		account := "testString"
+		listImageExemptionsPath := "/va/api/v4/exemptions/image/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3504,21 +3511,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					// TODO: Add check for includeScope query parameter
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListImageExemptions with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListImageExemptionsOptions model
-				listImageExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListImageExemptionsOptions)
+				listImageExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListImageExemptionsOptions)
 				listImageExemptionsOptionsModel.Resource = core.StringPtr("testString")
 				listImageExemptionsOptionsModel.IncludeScope = core.BoolPtr(false)
 				listImageExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3541,9 +3548,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ListImageExemptions(listImageExemptionsOptions *ListImageExemptionsOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		listImageExemptionsPath := "/va/api/v3/exemptions/image/testString"
+		account := "testString"
+		listImageExemptionsPath := "/va/api/v4/exemptions/image/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3568,18 +3575,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListImageExemptions successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the ListImageExemptionsOptions model
-				listImageExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListImageExemptionsOptions)
+				listImageExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListImageExemptionsOptions)
 				listImageExemptionsOptionsModel.Resource = core.StringPtr("testString")
 				listImageExemptionsOptionsModel.IncludeScope = core.BoolPtr(false)
 				listImageExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3630,11 +3637,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListImageExemptions successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -3646,7 +3653,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the ListImageExemptionsOptions model
-				listImageExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListImageExemptionsOptions)
+				listImageExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListImageExemptionsOptions)
 				listImageExemptionsOptionsModel.Resource = core.StringPtr("testString")
 				listImageExemptionsOptionsModel.IncludeScope = core.BoolPtr(false)
 				listImageExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3659,17 +3666,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke ListImageExemptions with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListImageExemptionsOptions model
-				listImageExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListImageExemptionsOptions)
+				listImageExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListImageExemptionsOptions)
 				listImageExemptionsOptionsModel.Resource = core.StringPtr("testString")
 				listImageExemptionsOptionsModel.IncludeScope = core.BoolPtr(false)
 				listImageExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3682,7 +3689,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 				// Construct a second instance of the ListImageExemptionsOptions model with no property values
-				listImageExemptionsOptionsModelNew := new(vulnerabilityadvisorv3.ListImageExemptionsOptions)
+				listImageExemptionsOptionsModelNew := new(vulnerabilityadvisorv4.ListImageExemptionsOptions)
 				// Invoke operation with invalid model (negative test)
 				result, response, operationErr = vulnerabilityAdvisorService.ListImageExemptions(listImageExemptionsOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -3703,17 +3710,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListImageExemptions successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListImageExemptionsOptions model
-				listImageExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListImageExemptionsOptions)
+				listImageExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListImageExemptionsOptions)
 				listImageExemptionsOptionsModel.Resource = core.StringPtr("testString")
 				listImageExemptionsOptionsModel.IncludeScope = core.BoolPtr(false)
 				listImageExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3732,9 +3739,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ListBulkImageExemptions(listBulkImageExemptionsOptions *ListBulkImageExemptionsOptions) - Operation response error`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		listBulkImageExemptionsPath := "/va/api/v3/exemptions/images"
+		account := "testString"
+		listBulkImageExemptionsPath := "/va/api/v4/exemptions/images"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3749,21 +3756,21 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListBulkImageExemptions with error: Operation response processing error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListBulkImageExemptionsOptions model
-				listBulkImageExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListBulkImageExemptionsOptions)
+				listBulkImageExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListBulkImageExemptionsOptions)
 				listBulkImageExemptionsOptionsModel.Body = []string{"us.icr.io/birds/woodpecker:green", "us.icr.io/birds/grebe:crested"}
 				listBulkImageExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -3785,9 +3792,9 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 		})
 	})
 	Describe(`ListBulkImageExemptions(listBulkImageExemptionsOptions *ListBulkImageExemptionsOptions)`, func() {
-		account := "testString"
 		acceptLanguage := "testString"
-		listBulkImageExemptionsPath := "/va/api/v3/exemptions/images"
+		account := "testString"
+		listBulkImageExemptionsPath := "/va/api/v4/exemptions/images"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3827,18 +3834,18 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListBulkImageExemptions successfully with retries`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 				vulnerabilityAdvisorService.EnableRetries(0, 0)
 
 				// Construct an instance of the ListBulkImageExemptionsOptions model
-				listBulkImageExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListBulkImageExemptionsOptions)
+				listBulkImageExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListBulkImageExemptionsOptions)
 				listBulkImageExemptionsOptionsModel.Body = []string{"us.icr.io/birds/woodpecker:green", "us.icr.io/birds/grebe:crested"}
 				listBulkImageExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3903,11 +3910,11 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListBulkImageExemptions successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
@@ -3919,7 +3926,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(result).To(BeNil())
 
 				// Construct an instance of the ListBulkImageExemptionsOptions model
-				listBulkImageExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListBulkImageExemptionsOptions)
+				listBulkImageExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListBulkImageExemptionsOptions)
 				listBulkImageExemptionsOptionsModel.Body = []string{"us.icr.io/birds/woodpecker:green", "us.icr.io/birds/grebe:crested"}
 				listBulkImageExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3931,17 +3938,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 
 			})
 			It(`Invoke ListBulkImageExemptions with error: Operation validation and request error`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListBulkImageExemptionsOptions model
-				listBulkImageExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListBulkImageExemptionsOptions)
+				listBulkImageExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListBulkImageExemptionsOptions)
 				listBulkImageExemptionsOptionsModel.Body = []string{"us.icr.io/birds/woodpecker:green", "us.icr.io/birds/grebe:crested"}
 				listBulkImageExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -3953,7 +3960,7 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 				// Construct a second instance of the ListBulkImageExemptionsOptions model with no property values
-				listBulkImageExemptionsOptionsModelNew := new(vulnerabilityadvisorv3.ListBulkImageExemptionsOptions)
+				listBulkImageExemptionsOptionsModelNew := new(vulnerabilityadvisorv4.ListBulkImageExemptionsOptions)
 				// Invoke operation with invalid model (negative test)
 				result, response, operationErr = vulnerabilityAdvisorService.ListBulkImageExemptions(listBulkImageExemptionsOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
@@ -3974,17 +3981,17 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 				}))
 			})
 			It(`Invoke ListBulkImageExemptions successfully`, func() {
-				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-					URL:            testServer.URL,
-					Authenticator:  &core.NoAuthAuthenticator{},
-					Account:        core.StringPtr(account),
+				vulnerabilityAdvisorService, serviceErr := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
 					AcceptLanguage: core.StringPtr(acceptLanguage),
+					Account: core.StringPtr(account),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(vulnerabilityAdvisorService).ToNot(BeNil())
 
 				// Construct an instance of the ListBulkImageExemptionsOptions model
-				listBulkImageExemptionsOptionsModel := new(vulnerabilityadvisorv3.ListBulkImageExemptionsOptions)
+				listBulkImageExemptionsOptionsModel := new(vulnerabilityadvisorv4.ListBulkImageExemptionsOptions)
 				listBulkImageExemptionsOptionsModel.Body = []string{"us.icr.io/birds/woodpecker:green", "us.icr.io/birds/grebe:crested"}
 				listBulkImageExemptionsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -4003,13 +4010,13 @@ var _ = Describe(`VulnerabilityAdvisorV3`, func() {
 	})
 	Describe(`Model constructor tests`, func() {
 		Context(`Using a service client instance`, func() {
-			account := "testString"
 			acceptLanguage := "testString"
-			vulnerabilityAdvisorService, _ := vulnerabilityadvisorv3.NewVulnerabilityAdvisorV3(&vulnerabilityadvisorv3.VulnerabilityAdvisorV3Options{
-				URL:            "http://vulnerabilityadvisorv3modelgenerator.com",
-				Authenticator:  &core.NoAuthAuthenticator{},
-				Account:        core.StringPtr(account),
+			account := "testString"
+			vulnerabilityAdvisorService, _ := vulnerabilityadvisorv4.NewVulnerabilityAdvisorV4(&vulnerabilityadvisorv4.VulnerabilityAdvisorV4Options{
+				URL:           "http://vulnerabilityadvisorv4modelgenerator.com",
+				Authenticator: &core.NoAuthAuthenticator{},
 				AcceptLanguage: core.StringPtr(acceptLanguage),
+				Account: core.StringPtr(account),
 			})
 			It(`Invoke NewAccountReportQueryPathOptions successfully`, func() {
 				// Construct an instance of the AccountReportQueryPathOptions model
@@ -4246,7 +4253,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {


### PR DESCRIPTION
## PR summary

replaces vav3 API with vav4 API
crv1 API regenerated using automation for consistency 


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
The VA v3 API is deprecated.

## What is the new behavior?  
The VA v4 will become default. 
There are some new fields in results but otherwise is backward compatibe

## Does this PR introduce a breaking change?    
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Existing applications will need to update the package references to `vulnerabilityadvisorv4` 