### PR TITLE
Added some missing structs and fields.

### DIFF
--- a/vulnerabilityadvisorv4/vulnerability_advisor_v4.go
+++ b/vulnerabilityadvisorv4/vulnerability_advisor_v4.go
@@ -1954,6 +1954,9 @@ type ScanReport struct {
 	// https://{DomainName}/apidocs/container-registry/va#getting-started-vulnerability-report-status-codes.
 	Status *string `json:"status" validate:"required"`
 
+	// The detailed vulnerability assessment status for each scan engine
+	StatusDetail *StatusDetail `json:"status_detail" validate:"required"`
+
 	// Vulnerabilities found in the container image at the scan time.
 	Vulnerabilities []ScanresultCVE `json:"vulnerabilities" validate:"required"`
 }
@@ -1982,6 +1985,70 @@ func UnmarshalScanReport(m map[string]json.RawMessage, result interface{}) (err 
 		return
 	}
 	err = core.UnmarshalModel(m, "vulnerabilities", &obj.Vulnerabilities, UnmarshalScanresultCVE)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "status_detail", &obj.StatusDetail, UnmarshalStatusDetail)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+type StatusDetail struct {
+	IBMVA       *ScanStatusDetail `json:"ibm_va,omitempty"`
+	PrismaCloud *ScanStatusDetail `json:"prisma_cloud,omitempty"`
+}
+
+// UnmarshalScanReportList unmarshals an instance of ScanReportList from the specified map of raw messages.
+func UnmarshalStatusDetail(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(StatusDetail)
+	err = core.UnmarshalModel(m, "ibm_va", &obj.IBMVA, UnmarshalScanStatusDetail)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "prisma_cloud", &obj.PrismaCloud, UnmarshalScanStatusDetail)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+type ScanStatusDetail struct {
+	ScanUUID   *string `json:"scan_uuid"`
+	ScanTime   *int    `json:"scan_time"`
+	StatusCode *int    `json:"status_code"`
+	Status     *string `json:"status"`
+	Message    *string `json:"message,omitempty"`
+	ErrorCode  *string `json:"error_code,omitempty"`
+}
+
+// UnmarshalScanresultConfigurationIssue unmarshals an instance of ScanresultConfigurationIssue from the specified map of raw messages.
+func UnmarshalScanStatusDetail(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(ScanStatusDetail)
+	err = core.UnmarshalPrimitive(m, "scan_uuid", &obj.ScanUUID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "scan_time", &obj.ScanTime)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "status_code", &obj.StatusCode)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "status", &obj.Status)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "message", &obj.Message)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "error_code", &obj.ErrorCode)
 	if err != nil {
 		return
 	}
@@ -2281,6 +2348,9 @@ type ScanresultCVE struct {
 
 	// Total number of security notices that contain fixes for this CVE.
 	TotalSecurityNoticeCount *int64 `json:"total_security_notice_count" validate:"required"`
+
+	// The scan engine(s) that detected the CVE
+	ScanEngines []string `json:"scan_engines" validate:"required"`
 }
 
 // UnmarshalScanresultCVE unmarshals an instance of ScanresultCVE from the specified map of raw messages.
@@ -2318,6 +2388,10 @@ func UnmarshalScanresultCVE(m map[string]json.RawMessage, result interface{}) (e
 	if err != nil {
 		return
 	}
+	err = core.UnmarshalPrimitive(m, "scan_engines", &obj.ScanEngines)
+	if err != nil {
+		return
+	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
@@ -2338,6 +2412,9 @@ type ScanresultConfigurationIssue struct {
 
 	// Not supported.
 	Type *string `json:"type" validate:"required"`
+
+	// The scan engine(s) that detected the configuration issue
+	ScanEngines []string `json:"scan_engines" validate:"required"`
 }
 
 // UnmarshalScanresultConfigurationIssue unmarshals an instance of ScanresultConfigurationIssue from the specified map of raw messages.
@@ -2428,6 +2505,12 @@ type ScanresultSecurityNotice struct {
 
 	// Package updates that contain fixes for this vulnerability.
 	VulnerablePackages []ScanresultPackageFixes `json:"vulnerable_packages" validate:"required"`
+
+	// The scan engine(s) that detected the security notice
+	ScanEngines []string `json:"scan_engines" validate:"required"`
+
+	// The reference of the security notice
+	References []string `json:"references"`
 }
 
 // UnmarshalScanresultSecurityNotice unmarshals an instance of ScanresultSecurityNotice from the specified map of raw messages.
@@ -2450,6 +2533,14 @@ func UnmarshalScanresultSecurityNotice(m map[string]json.RawMessage, result inte
 		return
 	}
 	err = core.UnmarshalModel(m, "vulnerable_packages", &obj.VulnerablePackages, UnmarshalScanresultPackageFixes)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "scan_engines", &obj.ScanEngines)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "references", &obj.References)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Adds missing struct to parse the data out from vulnerability advisor response.
**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->
I extended the following structures:
`ScanReport` struct got `StatusDetail` struct. 

The `StatusDetail` struct contains `ScanStatusDetail`(s) each `ScanStatusDetail` has for its' name the represented scan engine. I'm aware of `ibm_va` and `prisma_cloud` at the moment.

The `ScanresultCVE` struct got extended with `ScanEngines` string map.

The `ScanresultConfigurationIssue` struct got extended with `ScanEngines` string map.

The `ScanresultSecurityNotice` struct got extended with `ScanEngines` string map and `References` string map.

Note: All of the above structs are already present in the vulnerability advisor response, but they never got parsed out.

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->
Setting the default headers for the Vulnerability Advisor client to `"ibm_va,prisma_cloud"` will result returning both scan engine results as `scanReport`:
E.g.:
```
if usePrismaScanToo {
	vaClient.SetDefaultHeaders(http.Header{"Scan-Engines": []string{"ibm_va,prisma_cloud"}})
}
imageReportQueryPathOptions := vaClient.NewImageReportQueryPathOptions(image)
scanReport, _, err := vaClient.ImageReportQueryPath(imageReportQueryPathOptions)
```

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->