### PR TITLE
fix(project): Address Travis's broken Go setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
-go:
-  - "1.18.10" # Highest minor version available according to https://pkg.go.dev/golang.org/dl#section-readme
-  - "1.19.13" # Highest minor version available according to https://pkg.go.dev/golang.org/dl#section-readme
-  - "1.20.14" # Highest minor version available according to https://pkg.go.dev/golang.org/dl#section-readme
+env:
+  - GO_VERSION="module" # The oldest version we claim to support
+  - GO_VERSION="1.21.x" # The oldest version that enforces the minimum version of imported modules
+  - GO_VERSION="stable" # The latest version
 
 dist: jammy
 
@@ -15,6 +15,14 @@ before_install:
   - pyenv versions
 
 install:
+  # Travis's docs claim to use gimme to install the go version but they in fact use go install. This does not support
+  # the 1.18.x syntax or any equivalent. Travis's version of gimme is also unmaintained and broken. Use a maintained
+  # version from the urfave org in its place.
+  - curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/urfave/gimme/main/gimme
+  - chmod +x ~/bin/gimme
+  - gimme version
+  - eval "$(gimme "$GO_VERSION")"
+  - go env
   - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.60.2
 
 script:


### PR DESCRIPTION
The docs are still aligned with Travis using gimme but now they use go install.

Fix it by manually using a maintained version of gimme. Go install doesn't allow you to install the latest patch of a minor version.

## PR summary
<!-- please include a brief summary of the changes in this PR -->

**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->